### PR TITLE
Timeline v2

### DIFF
--- a/pytr/api.py
+++ b/pytr/api.py
@@ -457,6 +457,15 @@ class TradeRepublicApi:
     async def timeline_detail_savings_plan(self, savings_plan_id):
         return await self.subscribe({'type': 'timelineDetail', 'savingsPlanId': savings_plan_id})
 
+    async def timeline_transactions(self, after=None):
+        return await self.subscribe({'type': 'timelineTransactions', 'after': after})
+
+    async def timeline_activity_log(self, after=None):
+        return await self.subscribe({'type': 'timelineActivityLog', 'after': after})
+
+    async def timeline_detail_v2(self, timeline_id):
+        return await self.subscribe({'type': 'timelineDetailV2', 'id': timeline_id})
+
     async def search_tags(self):
         return await self.subscribe({'type': 'neonSearchTags'})
 

--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -66,7 +66,7 @@ class DL:
             self.log.info('Created history file')
 
     async def dl_loop(self):
-        await self.tl.get_next_timeline(max_age_timestamp=self.since_timestamp)
+        await self.tl.get_next_timeline_transactions(max_age_timestamp=self.since_timestamp)
 
         while True:
             try:
@@ -74,9 +74,11 @@ class DL:
             except TradeRepublicError as e:
                 self.log.fatal(str(e))
 
-            if subscription['type'] == 'timeline':
-                await self.tl.get_next_timeline(response, max_age_timestamp=self.since_timestamp)
-            elif subscription['type'] == 'timelineDetail':
+            if subscription['type'] == 'timelineTransactions':
+                await self.tl.get_next_timeline_transactions(response, max_age_timestamp=self.since_timestamp)
+            elif subscription['type'] == 'timelineActivityLog':
+                await self.tl.get_next_timeline_activity_log(response, max_age_timestamp=self.since_timestamp)
+            elif subscription['type'] == 'timelineDetailV2':
                 await self.tl.timelineDetail(response, self, max_age_timestamp=self.since_timestamp)
             else:
                 self.log.warning(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")

--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -88,17 +88,26 @@ class DL:
         send asynchronous request, append future with filepath to self.futures
         '''
         doc_url = doc['action']['payload']
+        if subtitleText is None:
+            subtitleText = ''
 
-        date = doc['detail']
-        iso_date = '-'.join(date.split('.')[::-1])
+        try:
+            date = doc['detail']
+            iso_date = '-'.join(date.split('.')[::-1])
+        except KeyError:
+            date = ''
+            iso_date = ''
         doc_id = doc['id']
 
         # extract time from subtitleText
-        time = re.findall('um (\\d+:\\d+) Uhr', subtitleText)
-        if time == []:
+        try:
+            time = re.findall('um (\\d+:\\d+) Uhr', subtitleText)
+            if time == []:
+                time = ''
+            else:
+                time = f' {time[0]}'
+        except TypeError:
             time = ''
-        else:
-            time = f' {time[0]}'
 
         if subfolder is not None:
             directory = self.output_path / subfolder

--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -143,6 +143,7 @@ class DL:
                 return
             else:
                 filepath = filepath_with_doc_id
+        doc['local filepath'] = str(filepath)
         self.filepaths.append(filepath)
 
         if filepath.is_file() is False:

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -231,7 +231,7 @@ def export_transactions(input_path, output_path, lang='auto'):
 
             try:
                 decdot = i18n['decimal dot'][lang]
-                amount = str(event['amount']['value']).replace('.', decdot)
+                amount = str(abs(event['amount']['value'])).replace('.', decdot)
             except (KeyError, TypeError):
                 continue
 
@@ -239,7 +239,7 @@ def export_transactions(input_path, output_path, lang='auto'):
             if event["eventType"] in ("PAYMENT_INBOUND", "PAYMENT_INBOUND_SEPA_DIRECT_DEBIT"):
                 f.write(csv_fmt.format(date=date, type=i18n['deposit'][lang], value=amount))
             elif event["eventType"] == "PAYMENT_OUTBOUND":
-                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=abs(amount)))
+                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount))
             elif event["eventType"] == "INTEREST_PAYOUT_CREATED":
                 f.write(csv_fmt.format(date=date, type=i18n['interest'][lang], value=amount))
             # Dividend - Shares
@@ -247,7 +247,7 @@ def export_transactions(input_path, output_path, lang='auto'):
                 # TODO: Implement reinvestment
                 log.warning('Detected reivestment, skipping... (not implemented yet)')
             elif event["eventType"] == "card_successful_transaction":
-                f.write(csv_fmt.format(date=date, type=i18n['card transaction'][lang], value=abs(amount)))
+                f.write(csv_fmt.format(date=date, type=i18n['card transaction'][lang], value=amount))
 
     log.info('Deposit creation finished!')
 

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -310,7 +310,7 @@ class Timeline:
             self.num_timelines = 0
             await self.tr.timeline_activity_log()
         else:
-            timestamp = response['items'][-1]['timestamp']
+            timestamp = datetime.fromisoformat(response['items'][-1]['timestamp']).timestamp()
             self.num_timelines += 1
             # print(json.dumps(response))
             self.num_timeline_details += len(response['items'])

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -217,7 +217,7 @@ def export_transactions(input_path, output_path, lang='auto'):
         f.write(header)
 
         for event in timeline:
-            dateTime = datetime.fromisoformat(event['timestamp'])
+            dateTime = datetime.fromisoformat(event['timestamp'][:19])
             date = dateTime.strftime('%Y-%m-%d')
 
             title = event['title']

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -310,7 +310,7 @@ class Timeline:
             self.num_timelines = 0
             await self.tr.timeline_activity_log()
         else:
-            timestamp = datetime.fromisoformat(response['items'][-1]['timestamp']).timestamp()
+            timestamp = datetime.fromisoformat(response['items'][-1]['timestamp'][:19]).timestamp()
             self.num_timelines += 1
             # print(json.dumps(response))
             self.num_timeline_details += len(response['items'])

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -426,14 +426,14 @@ class Timeline:
                 for doc in section['data']:
                     try:
                         timestamp = datetime.strptime(doc['detail'], '%d.%m.%Y').timestamp() * 1000
-                    except ValueError:
+                    except (ValueError, KeyError):
                         timestamp = datetime.now().timestamp() * 1000
                     if max_age_timestamp == 0 or max_age_timestamp < timestamp:
                         # save all savingsplan documents in a subdirectory
                         title = f"{doc['title']} - {event['title']}"
                         if event['eventType'] in ["ACCOUNT_TRANSFER_INCOMING", "ACCOUNT_TRANSFER_OUTGOING"]:
                             title += f" - {event['subtitle']}"
-                        dl.dl_doc(doc, title, doc['detail'], subfolder)
+                        dl.dl_doc(doc, title, doc.get('detail'), subfolder)
 
         if self.received_detail == self.num_timeline_details:
             self.log.info('Received all details')


### PR DESCRIPTION
Adds support for new Trade Republic API parts.
TR nows uses `timingTransaction` and `timelineActivityLog` instead of `timing` as well as `timingDetailV2` instead of `timingDetail`. 
As the new card transactions as well as saveback and round-up benefits are not included in the old API elements this change is required to include these. This pull-request fixes #53.

The naming of the output files and the format of the output JSON can be different from earlier versions.
The naming of the output files might be adapted further as they are now more information available in the  `timingDetailV2` data.
