### PR TITLE
Add note field to account_transcations.csv and add atm withdraw and card order type

### DIFF
--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -147,6 +147,17 @@ def export_transactions(input_path, output_path, lang='auto'):
             "pt": "Valor",
             "ru": "\u0417\u043D\u0430\u0447\u0435\u043D\u0438\u0435",
         },
+        "note": {
+            "cs": "Poznámka",
+            "de": "Notiz",
+            "en": "Note",
+            "es": "Nota",
+            "fr": "Note",
+            "it": "Nota",
+            "nl": "Noot",
+            "pt": "Nota",
+            "ru": "\u041f\u0440\u0438\u043c\u0435\u0447\u0430\u043d\u0438\u0435",
+        },
         "deposit": {
             "cs": 'Vklad',
             "de": 'Einlage',
@@ -234,8 +245,8 @@ def export_transactions(input_path, output_path, lang='auto'):
     log.info('Write deposit entries')
     with open(output_path, 'w', encoding='utf-8') as f:
         # f.write('Datum;Typ;Stück;amount;Wert;Gebühren;ISIN;name\n')
-        csv_fmt = '{date};{type};{value}\n'
-        header = csv_fmt.format(date=i18n['date'][lang], type=i18n['type'][lang], value=i18n['value'][lang])
+        csv_fmt = '{date};{type};{value};{note}\n'
+        header = csv_fmt.format(date=i18n['date'][lang], type=i18n['type'][lang], value=i18n['value'][lang], note=i18n['note'][lang])
         f.write(header)
 
         for event in timeline:
@@ -259,21 +270,21 @@ def export_transactions(input_path, output_path, lang='auto'):
 
             # Cash in
             if event["eventType"] in ("PAYMENT_INBOUND", "PAYMENT_INBOUND_SEPA_DIRECT_DEBIT"):
-                f.write(csv_fmt.format(date=date, type=i18n['deposit'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['deposit'][lang], value=amount, note=''))
             elif event["eventType"] == "PAYMENT_OUTBOUND":
-                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount, note=''))
             elif event["eventType"] == "INTEREST_PAYOUT_CREATED":
-                f.write(csv_fmt.format(date=date, type=i18n['interest'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['interest'][lang], value=amount, note=''))
             # Dividend - Shares
             elif title == 'Reinvestierung':
                 # TODO: Implement reinvestment
                 log.warning('Detected reivestment, skipping... (not implemented yet)')
             elif event["eventType"] == "card_successful_transaction":
-                f.write(csv_fmt.format(date=date, type=i18n['card transaction'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount, note=i18n['card transaction'][lang]))
             elif event["eventType"] == "card_successful_atm_withdrawal":
-                f.write(csv_fmt.format(date=date, type=i18n['card atm withdrawal'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount, note=i18n['card atm withdrawal'][lang]))
             elif event["eventType"] == "card_order_billed":
-                f.write(csv_fmt.format(date=date, type=i18n['card order'][lang], value=amount))
+                f.write(csv_fmt.format(date=date, type=i18n['removal'][lang], value=amount, note=i18n['card order'][lang]))
 
     log.info('Deposit creation finished!')
 

--- a/pytr/utils.py
+++ b/pytr/utils.py
@@ -191,6 +191,28 @@ def export_transactions(input_path, output_path, lang='auto'):
             "pt": 'Transakcja kartą',
             "ru": '\u041e\u043f\u0435\u0440\u0430\u0446\u0438\u044f\u0020\u043f\u043e\u0020\u043a\u0430\u0440\u0442\u0435',
         },
+        "card atm withdrawal": {
+            "cs": 'Výběr hotovosti',
+            "de": 'Barabhebung',
+            "en": 'ATM withdrawal',
+            "es": 'Retiradas de efectivo',
+            "fr": 'Retrait en espèces',
+            "it": 'Prelievo di contanti',
+            "nl": 'Geldopname',
+            "pt": 'Levantamento de dinheiro',
+            "ru": '\u0412\u044b\u0434\u0430\u0447\u0430\u0020\u043d\u0430\u043b\u0438\u0447\u043d\u044b\u0445',
+        },
+        "card order": {
+            "cs": 'Poplatek za kartu',
+            "de": 'Kartengebühr',
+            "en": 'Card fee',
+            "es": 'Transacción con tarjeta',
+            "fr": 'Frais de carte',
+            "it": 'Tassa sulla carta',
+            "nl": 'Kosten kaart',
+            "pt": 'Taxa do cartão',
+            "ru": '\u041f\u043b\u0430\u0442\u0430\u0020\u0437\u0430\u0020\u043e\u0431\u0441\u043b\u0443\u0436\u0438\u0432\u0430\u043d\u0438\u0435\u0020\u043a\u0430\u0440\u0442\u044b',
+        },
         "decimal dot": {
             "cs": ',',
             "de": ',',
@@ -248,6 +270,10 @@ def export_transactions(input_path, output_path, lang='auto'):
                 log.warning('Detected reivestment, skipping... (not implemented yet)')
             elif event["eventType"] == "card_successful_transaction":
                 f.write(csv_fmt.format(date=date, type=i18n['card transaction'][lang], value=amount))
+            elif event["eventType"] == "card_successful_atm_withdrawal":
+                f.write(csv_fmt.format(date=date, type=i18n['card atm withdrawal'][lang], value=amount))
+            elif event["eventType"] == "card_order_billed":
+                f.write(csv_fmt.format(date=date, type=i18n['card order'][lang], value=amount))
 
     log.info('Deposit creation finished!')
 


### PR DESCRIPTION
Adds two new types to `account_transcations.csv`: ATM withdraw (Barabhebung) and Card fee (Kartenausgabegebühr). 
To ease import to Portfolio Performance those are classified as 'removal' and a  new field ('note') with the actual removal reason is added.

![Screenshot at 2024-06-27 09-56-07](https://github.com/pytr-org/pytr/assets/26622301/88d9489d-bb0c-490e-8ea5-a609badca227)
