### PR TITLE
Hide PIN input

### DIFF
--- a/pytr/account.py
+++ b/pytr/account.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pygments import highlight, lexers, formatters
 import time
+from getpass import getpass
 
 from pytr.api import TradeRepublicApi, CREDENTIALS_FILE
 from pytr.utils import get_logger
@@ -45,7 +46,7 @@ def login(phone_no=None, pin=None, web=True):
 
         if pin is None:
             print('Please enter your TradeRepublic pin:')
-            pin = input()
+            pin = getpass(prompt='Pin (Input is hidden):')
 
         print('Save credentials? Type "y" to save credentials:')
         save = input()


### PR DESCRIPTION
This hides the PIN while it is entered using `getpass()`.

I have only tested this with a Linux terminal, Windows Powershell and Windows cmd.exe. It works there. I don't know what else people use to run this though.

An alternative could be https://github.com/asweigart/pwinput. That is also closer to the way the Trade Republic app hides the PIN but it requires using an extra package.