### PR TITLE
timeline: retrieve next timeline, only if in the response is at least one new entry

### DIFF
--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -66,15 +66,16 @@ class Timeline:
             await self.tr.timeline_activity_log()
         else:
             self.num_timelines += 1
-            added_last_event = True
+            added_last_event = False
             for event in response['items']:
                 if self.max_age_timestamp == 0 or datetime.fromisoformat(event['timestamp'][:19]).timestamp() >= self.max_age_timestamp:
                     if event['id'] in self.timeline_events:
                         self.log.warning(f"Received duplicate event {event['id'] }")
+                    else:
+                        added_last_event = True
                     event['source'] = "timelineActivity"
                     self.timeline_events[event['id']] = event
                 else:
-                    added_last_event = False
                     break
 
             self.log.info(f'Received #{self.num_timelines:<2} timeline activity log')


### PR DESCRIPTION
On my account, I get the message "Received duplicate event..." within an endless loop (all the time with the same 30 "duplicate events), so is it possible to set the variable added_last_event only, if there are no duplicates?