### PR TITLE
Refactor parsing and formatting

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -20,6 +20,7 @@ class DL:
         history_file='pytr_history',
         max_workers=8,
         universal_filepath=False,
+        sort_export=False
     ):
         '''
         tr: api object
@@ -33,6 +34,7 @@ class DL:
         self.filename_fmt = filename_fmt
         self.since_timestamp = since_timestamp
         self.universal_filepath = universal_filepath
+        self.sort_export = sort_export
 
         self.session = FuturesSession(max_workers=max_workers, session=self.tr._websession)
         self.futures = []

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -204,8 +204,6 @@ class Event:
         Returns:
             Tuple[Optional[float]]: [Tax]
         """
-        tax = None
-        return_values = {}
         # tax keywords
         tax_keys = {"Steuer", "Steuern"}
         # Gather all section dicts
@@ -219,19 +217,15 @@ class Event:
             data = transaction_dict.get("data", [{}])
             tax_dicts = filter(
                 lambda x: x["title"] in tax_keys, data
-            )  # + detailed_dicts)
+            )
             # Iterate over dicts containing tax information and parse each one
             for tax_dict in tax_dicts:
-                # print(tax_dict)
                 unparsed_tax_val = tax_dict.get("detail", {}).get("text", "")
                 parsed_tax_val = re.sub("[^\,\.\d-]", "", unparsed_tax_val).replace(
                     ",", "."
                 )
                 if parsed_tax_val != "" and float(parsed_tax_val) != 0.0:
-                    return_values[tax_dict.get("title", "")] = float(parsed_tax_val)
-        # Parse return_values dict to tax
-        tax = next(filter(lambda x: isinstance(x, float), return_values.values()), None)
-        return tax
+                    return float(parsed_tax_val)
 
     @staticmethod
     def _parse_card_note(event_json: Dict[Any, Any]) -> Optional[str]:

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -1,100 +1,240 @@
+from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum, auto
+import json
+from typing import Any, Dict, List, Optional, Tuple
 import re
 
-tr_eventType_to_pp_type = {
-    'INCOMING_TRANSFER': 'DEPOSIT',
-    'PAYMENT_INBOUND': 'DEPOSIT',
-    'PAYMENT_INBOUND_GOOGLE_PAY': 'DEPOSIT',
-    'PAYMENT_INBOUND_SEPA_DIRECT_DEBIT': 'DEPOSIT',
-    'card_refund': 'DEPOSIT',
 
-    'CREDIT': 'DIVIDENDS',
-    'ssp_corporate_action_invoice_cash': 'DIVIDENDS',
+class UnprocessedEventType(Enum):
+    SAVEBACK = auto()
+    TRADE_INVOICE = auto()
 
-    'INTEREST_PAYOUT_CREATED': 'INTEREST',
 
-    'OUTGOING_TRANSFER_DELEGATION': 'REMOVAL',
-    'PAYMENT_OUTBOUND': 'REMOVAL',
-    'card_failed_transaction': 'REMOVAL',
-    'card_order_billed': 'REMOVAL',
-    'card_successful_atm_withdrawal': 'REMOVAL',
-    'card_successful_transaction': 'REMOVAL',
+class PPEventType(Enum):
+    BUY = "Buy"
+    DEPOSIT = "Deposit"
+    DIVIDEND = "Dividend"
+    FEES = "Fees"
+    FEES_REFUND = "Fees Refund"
+    INTEREST = "Interest"
+    INTEREST_CHARGE = "Interest Charge"
+    REMOVAL = "Removal"
+    SELL = "Sell"
+    TAX_REFUND = "Tax Refund"
+    TAXES = "Taxes"
+    TRANSFER_IN = "Transfer (Inbound)"
+    TRANSFER_OUT = "Transfer (Outbound)"
 
-    'ORDER_EXECUTED': 'TRADE_INVOICE',
-    'SAVINGS_PLAN_EXECUTED': 'TRADE_INVOICE',
-    'SAVINGS_PLAN_INVOICE_CREATED': 'TRADE_INVOICE',
-    'TRADE_INVOICE': 'TRADE_INVOICE'
+
+class EventType(Enum):
+    PP_EVENT_TYPE = PPEventType
+    UNPROCESSED_EVENT_TYPE = UnprocessedEventType
+
+
+tr_eventType_mapping = {
+    # Deposits
+    "INCOMING_TRANSFER": PPEventType.DEPOSIT,
+    "INCOMING_TRANSFER_DELEGATION": PPEventType.DEPOSIT,
+    "PAYMENT_INBOUND": PPEventType.DEPOSIT,
+    "PAYMENT_INBOUND_GOOGLE_PAY": PPEventType.DEPOSIT,
+    "PAYMENT_INBOUND_SEPA_DIRECT_DEBIT": PPEventType.DEPOSIT,
+    "card_refund": PPEventType.DEPOSIT,
+    "card_successful_oct": PPEventType.DEPOSIT,
+    # Dividends
+    "CREDIT": PPEventType.DIVIDEND,
+    "ssp_corporate_action_invoice_cash": PPEventType.DIVIDEND,
+    # Interests
+    "INTEREST_PAYOUT": PPEventType.INTEREST,
+    "INTEREST_PAYOUT_CREATED": PPEventType.INTEREST,
+    # Removals
+    "OUTGOING_TRANSFER_DELEGATION": PPEventType.REMOVAL,
+    "PAYMENT_OUTBOUND": PPEventType.REMOVAL,
+    "card_failed_transaction": PPEventType.REMOVAL,
+    "card_order_billed": PPEventType.REMOVAL,
+    "card_successful_atm_withdrawal": PPEventType.REMOVAL,
+    "card_successful_transaction": PPEventType.REMOVAL,
+    # Saveback
+    "benefits_saveback_execution": UnprocessedEventType.SAVEBACK,
+    # Trade invoices
+    "ORDER_EXECUTED": UnprocessedEventType.TRADE_INVOICE,
+    "SAVINGS_PLAN_EXECUTED": UnprocessedEventType.TRADE_INVOICE,
+    "SAVINGS_PLAN_INVOICE_CREATED": UnprocessedEventType.TRADE_INVOICE,
+    "TRADE_INVOICE": UnprocessedEventType.TRADE_INVOICE,
+    # Tax refunds
+    "TAX_REFUND": PPEventType.TAX_REFUND,
+    # Taxes
+    "PRE_DETERMINED_TAX_BASE_EARNING": PPEventType.TAXES,
 }
 
+
+@dataclass
 class Event:
-    def __init__(self, event_json):
-        self.event = event_json
-        self.shares = ""
-        self.isin = ""
+    value: float
+    date: datetime
+    event_type: EventType
+    title: str
+    isin: Optional[str] = field(default=None)
+    note: Optional[str] = field(default=None)
+    shares: Optional[float] = field(default=None)
+    tax: Optional[float] = field(default=None)
+    fee: Optional[float] = field(default=None)
 
-        self.pp_type = tr_eventType_to_pp_type.get(self.event["eventType"], "")
-        self.body = self.event.get("body", "")
-        self.process_event()
+    @classmethod
+    def from_json(cls, event_json: Dict[Any, Any]):
+        """Deserializes the json file into an Event object
 
-    @property
-    def date(self):
-        dateTime = datetime.fromisoformat(self.event["timestamp"][:19])
-        return dateTime.strftime("%Y-%m-%d")
+        Args:
+            event_json (json): _description_
 
-    @property
-    def is_pp_relevant(self):
-        if self.event["eventType"] == "card_failed_transaction":
-            if self.event["status"] == "CANCELED":
-                return False
-        return self.pp_type != ""
+        Returns:
+            Event: Event object
+        """
+        value: float = event_json.get("amount", {}).get("value", None)
+        date: datetime = datetime.fromisoformat(event_json["timestamp"][:19])
+        event_type: EventType = tr_eventType_mapping.get(event_json["eventType"], None)
+        title: str = event_json["title"]
+        isin, shares, tax, note, fee = cls._parse_type_dependent_params(
+            event_type, event_json
+        )
+        return cls(value, date, event_type, title, isin, note, shares, tax, fee)
 
-    @property
-    def amount(self):
-        return str(self.event["amount"]["value"])
+    @classmethod
+    def _parse_type_dependent_params(
+        cls, event_type: EventType, event_json: Dict[Any, Any]
+    ) -> Tuple[Optional[float]]:
+        isin, shares, tax, note, fee = (None,) * 5
+        # Parse isin
+        if event_type is PPEventType.DIVIDEND:
+            isin = cls._parse_isin(event_json)
+            tax, note = cls._parse_tax_and_note(event_json)
+        # Parse shares
+        elif event_type is UnprocessedEventType.TRADE_INVOICE:
+            isin = cls._parse_isin(event_json)
+            shares, fee = cls._parse_shares_and_fee(event_json)
+            tax, note = cls._parse_tax_and_note(event_json)
+        # Parse taxes
+        elif event_type is PPEventType.INTEREST:
+            tax, note = cls._parse_tax_and_note(event_json)
+        # Parse card notes
+        elif event_type in [PPEventType.DEPOSIT, PPEventType.REMOVAL]:
+            note = cls._parse_card_note(event_json)
+        return isin, shares, tax, note, fee
 
-    @property
-    def note(self):
-        if self.event["eventType"].find("card_") == 0:
-            return self.event["eventType"]
-        else:
-            return ""
+    @staticmethod
+    def _parse_isin(event_json: Dict[Any, Any]) -> str:
+        """Parses the isin
 
-    @property
-    def title(self):
-        return self.event["title"]
+        Args:
+            event_json (Dict[Any, Any]): _description_
 
-    def determine_pp_type(self):
-        if self.pp_type == "TRADE_INVOICE":
-            if self.event["amount"]["value"] < 0:
-                self.pp_type = "BUY"
-            else:
-                self.pp_type = "SELL"
+        Returns:
+            str: isin
+        """
+        sections = event_json.get("details", {}).get("sections", [{}])
+        isin = event_json.get("icon", "")
+        isin = isin[isin.find("/") + 1 :]
+        isin = isin[: isin.find("/")]
+        isin2 = isin
+        for section in sections:
+            action = section.get("action", None)
+            if action and action.get("type", {}) == "instrumentDetail":
+                isin2 = section.get("action", {}).get("payload")
+                break
+        if isin != isin2:
+            isin = isin2
+        return isin
 
-    def determine_shares(self):
-        if self.pp_type == "TRADE_INVOICE":
-            sections = self.event.get("details", {}).get("sections", [{}])
-            for section in sections:
-                if section.get("title") == "Transaktion":
-                    amount = section.get("data", [{}])[0]["detail"]["text"]
-                    amount = re.sub("[^\,\d-]", "", amount)
-                    self.shares = amount.replace(",", ".")
+    @staticmethod
+    def _parse_shares_and_fee(event_json: Dict[Any, Any]) -> Tuple[Optional[float]]:
+        """Parses the amount of shares and the applicable fee
 
-    def determine_isin(self):
-        if self.pp_type in ("DIVIDENDS", "TRADE_INVOICE"):
-            sections = self.event.get("details", {}).get("sections", [{}])
-            self.isin = self.event.get("icon", "")
-            self.isin = self.isin[self.isin.find("/") + 1 :]
-            self.isin = self.isin[: self.isin.find("/")]
-            isin2 = self.isin
-            for section in sections:
-                action = section.get("action", None)
-                if action and action.get("type", {}) == "instrumentDetail":
-                    isin2 = section.get("action", {}).get("payload")
-                    break
-            if self.isin != isin2:
-                self.isin = isin2
+        Args:
+            event_json (Dict[Any, Any]): _description_
 
-    def process_event(self):
-        self.determine_shares()
-        self.determine_isin()
-        self.determine_pp_type()
+        Returns:
+            Tuple[Optional[float]]: [shares, fee]
+        """
+        return_vals = {}
+        sections = event_json.get("details", {}).get("sections", [{}])
+        for section in sections:
+            if section.get("title") == "Transaktion":
+                data = section["data"]
+                shares_dicts = list(filter(lambda x: x["title"] in ["Aktien", "Anteile"], data))
+                fee_dicts = list(filter(lambda x: x["title"] == "Gebühr", data))
+                titles = ["shares"] * len(shares_dicts) + ["fee"] * len(fee_dicts)
+                for key, elem_dict in zip(titles, shares_dicts + fee_dicts):
+                    elem_unparsed = elem_dict.get("detail", {}).get("text", "")
+                    elem_parsed = re.sub("[^\,\d-]", "", elem_unparsed).replace(
+                        ",", "."
+                    )
+                    return_vals[key] = None if elem_parsed=="" or float(elem_parsed)==0. else float(elem_parsed)
+        return return_vals["shares"], return_vals["fee"]
+
+    @staticmethod
+    def _parse_tax_and_note(event_json: Dict[Any, Any]) -> Tuple[Optional[float], Optional[str]]:
+        """Hacky parse of the levied tax. @TODO Improve with better logs
+
+        Args:
+            event_json (Dict[Any, Any]): _description_
+
+        Returns:
+            Tuple[Optional[float], Optional[str]]: [Tax, tax info note]
+        """
+        tax, info = (None,) * 2
+        return_values = {}
+        # tax keywords
+        tax_kws = ["Steuer", "Steuern", "Kapitalertragsteuer", "Solidaritätszuschlag"]
+        # Gather all section dicts
+        sections = event_json.get("details", {}).get("sections", [{}])
+        # Gather all dicts pertaining to transactions
+        transaction_dicts = list(
+            filter(lambda x: x["title"] in ["Transaktion", "Geschäft"], sections)
+        )
+        for transaction_dict in transaction_dicts:
+            # Check for "Steuer" and "infoPage" dicts
+            data = transaction_dict.get("data", [{}])
+            # Check for "infoPage" section
+            action_dict = transaction_dict.get("action", {})
+            action_sections = []
+            if action_dict is not None and action_dict.get("type", "") == "infoPage":
+                action_sections = action_dict.get("payload",{}).get("section",[])
+            detailed_dicts = []
+            if len(action_sections) == 3:
+                detailed_dicts = sections[1].get("data", [])
+            # Concatenate all found tax dicts
+            tax_dicts = list(filter(lambda x: x["title"] in tax_kws, data + detailed_dicts))
+            # Iterate over dicts containing tax information and parse it
+            for tax_dict in tax_dicts:
+                unparsed_tax_val = tax_dict.get("detail", {}).get("text", "")
+                parsed_tax_val = re.sub("[^\,\d-]", "", unparsed_tax_val).replace(
+                    ",", "."
+                )
+                if parsed_tax_val != "" or float(parsed_tax_val) != 0.0:
+                    return_values[tax_dict.get("title", ""), ""] = parsed_tax_val
+        # Parse return_values dict to tax and info variables
+        tax = (
+            return_values.get("Steuer", None)
+            if "Steuer" in return_values.keys()
+            else return_values.get("Steuern", None)
+        )
+        if "Steuer" in return_values.keys():
+            tax = return_values["Steuer"], info = None
+        elif "Steuern" in return_values.keys():
+            tax = return_values["Steuern"]
+            info = f"Kapitalertragsteuer - {return_values['Kapitalertragsteuer']}€;\
+                Solidaritätszuschlag {return_values['Solidaritätszuschlag']}"
+        return tax, info
+
+    @staticmethod
+    def _parse_card_note(event_json: Dict[Any, Any]) -> Optional[str]:
+        """Parses the note associated with card transactions
+
+        Args:
+            event_json (Dict[Any, Any]): _description_
+
+        Returns:
+            Optional[str]: note
+        """
+        if event_json.get("eventType", "").startswith("card_"):
+            return event_json["eventType"]

--- a/pytr/event_formatter.py
+++ b/pytr/event_formatter.py
@@ -1,4 +1,5 @@
 from babel.numbers import format_decimal
+from copy import deepcopy
 
 from .event import Event, PPEventType, UnprocessedEventType
 from .translation import setup_translation
@@ -8,7 +9,7 @@ class EventCsvFormatter:
     def __init__(self, lang):
         self.lang = lang
         self.translate = setup_translation(language=self.lang)
-        self.csv_fmt = "{date};{type};{value};{note};{isin};{shares}\n"
+        self.csv_fmt = "{date};{type};{value};{note};{isin};{shares};{fees};{taxes}\n"
 
     def format_header(self) -> str:
         """Outputs header line
@@ -23,6 +24,8 @@ class EventCsvFormatter:
             note=self.translate("CSVColumn_Note"),
             isin=self.translate("CSVColumn_ISIN"),
             shares=self.translate("CSVColumn_Shares"),
+            fees=self.translate("CSVColumn_Fees"),
+            taxes=self.translate("CSVColumn_Taxes"),
         )
 
     def format(self, event: Event) -> str:
@@ -41,8 +44,8 @@ class EventCsvFormatter:
         # Initialize the csv line arguments
         kwargs = dict(
             zip(
-                ("date", "type", "value", "note", "isin", "shares"),
-                [[""] for _ in range(6)],
+                ("date", "type", "value", "note", "isin", "shares", "fees", "taxes"),
+                ["" for _ in range(8)],
             )
         )
 
@@ -50,81 +53,44 @@ class EventCsvFormatter:
         if event.event_type == UnprocessedEventType.TRADE_INVOICE:
             event.event_type = PPEventType.BUY if event.value < 0 else PPEventType.SELL
 
-        # Apply special formatting to date, type, value, note, isin and shares attributes
-        kwargs["date"] = [event.date.strftime("%Y-%m-%d")]
+        # Apply special formatting to the attributes
+        kwargs["date"] = event.date.strftime("%Y-%m-%d")
         if isinstance(event.event_type, PPEventType):
-            kwargs["type"] = [self.translate(event.event_type.value)]
-        kwargs["value"] = [event.value]
+            kwargs["type"] = self.translate(event.event_type.value)
+        kwargs["value"] = format_decimal(
+            event.value, locale=self.lang, decimal_quantization=True
+        )
         kwargs["note"] = (
-            [self.translate(event.note) + " - " + event.title]
+            self.translate(event.note) + " - " + event.title
             if event.note is not None
-            else [event.title]
+            else event.title
         )
         if event.isin is not None:
-            kwargs["isin"] = [event.isin]
+            kwargs["isin"] = event.isin
         if event.shares is not None:
-            kwargs["shares"] = [event.shares]
-        
-        # The following three event types potentially generate two or three csv lines per
-        # event (buy+deposit or dividend/interest/sell+tax or buy/sell+fee or sell+tax+fee)
-        # Handle SAVEBACK
+            kwargs["shares"] = format_decimal(
+                event.shares, locale=self.lang, decimal_quantization=False
+            )
+        if event.fees is not None:
+            kwargs["fees"] = format_decimal(
+                event.fees, locale=self.lang, decimal_quantization=True
+            )
+        if event.taxes is not None:
+            kwargs["taxes"] = format_decimal(
+                event.taxes, locale=self.lang, decimal_quantization=True
+            )
+        lines = self.csv_fmt.format(**kwargs)
+
+        # Generate BUY and DEPOSIT events from SAVEBACK event
         if event.event_type == UnprocessedEventType.SAVEBACK:
-            kwargs["type"] = [
-                self.translate(PPEventType.BUY.value),
-                self.translate(PPEventType.DEPOSIT.value),
-            ]
-            kwargs["value"] += [-kwargs["value"][0]]
-            kwargs["isin"] += [""]
-            kwargs["shares"] += [""]
-        # Handle Tax
-        if (
-            event.event_type
-            in [PPEventType.DIVIDEND, PPEventType.INTEREST, PPEventType.SELL]
-            and event.tax is not None
-        ):
-            kwargs["value"][0] += event.tax
-            kwargs["type"] += [self.translate(PPEventType.TAXES.value)]
-            kwargs["value"] += [event.tax]
-        # Handle Fee
-        if (
-            event.event_type in [PPEventType.BUY, PPEventType.SELL]
-            and event.fee is not None
-        ):
-            kwargs["value"][0] += event.fee
-            kwargs["type"] += [self.translate(PPEventType.FEES.value)]
-            kwargs["value"] += [event.fee]
+            kwargs["type"] = self.translate(PPEventType.BUY.value)
+            lines = self.csv_fmt.format(**kwargs)
+            kwargs["type"] = self.translate(PPEventType.DEPOSIT.value)
+            kwargs["value"] = format_decimal(
+                -event.value, locale=self.lang, decimal_quantization=True
+            )
+            kwargs["isin"] = ""
+            kwargs["shares"] = ""
+            lines += self.csv_fmt.format(**kwargs)
 
-        # Handle float to string conversion after tax and fee effects on the value field
-        if event.value is not None:
-            kwargs["value"] = [
-                format_decimal(value, locale=self.lang, decimal_quantization=True)
-                for value in kwargs["value"]
-            ]
-        if event.shares is not None:
-            kwargs["shares"] = [
-                (
-                    format_decimal(shares, locale=self.lang, decimal_quantization=False)
-                    if shares != ""
-                    else ""
-                )
-                for shares in kwargs["shares"]
-            ]
-
-        # Build the csv line formatting arguments when one event generates more than one line
-        single_line_generating_args = {
-            key: value[0] for key, value in kwargs.items() if len(value) == 1
-        }
-        multi_line_generating_args = {
-            key: value for key, value in kwargs.items() if len(value) > 1
-        }
-        list_kwargs = [
-            dict(zip(multi_line_generating_args.keys(), v))
-            for v in zip(*multi_line_generating_args.values())
-        ]
-        for line in list_kwargs:
-            line.update(single_line_generating_args)
-        if len(list_kwargs) == 0:
-            list_kwargs += [single_line_generating_args]
-        # Build csv line(s) from kwargs
-        lines = "".join(map(lambda x: self.csv_fmt.format(**x), list_kwargs))
         return lines

--- a/pytr/event_formatter.py
+++ b/pytr/event_formatter.py
@@ -1,0 +1,119 @@
+from babel.numbers import format_decimal
+from typing import Generator
+
+from .event import Event, PPEventType, UnprocessedEventType
+from .translation import setup_translation
+
+
+class EventCsvFormatter:
+    def __init__(self, lang):
+        self.lang = lang
+        self.translate = setup_translation(language=self.lang)
+        self.csv_fmt = "{date};{type};{value};{note};{isin};{shares}\n"
+        self.header = self.csv_fmt.format(
+            date=self.translate("CSVColumn_Date"),
+            type=self.translate("CSVColumn_Type"),
+            value=self.translate("CSVColumn_Value"),
+            note=self.translate("CSVColumn_Note"),
+            isin=self.translate("CSVColumn_ISIN"),
+            shares=self.translate("CSVColumn_Shares"),
+        )
+
+    def format_header(self) -> str:
+        """Outputs header line
+
+        Returns:
+            str: header line
+        """
+        return self.header
+
+    def format(self, event: Event) -> Generator[str, None, None]:
+        """Outputs a generator that yields one or multiple csv lines per event
+
+        Args:
+            event (Event): _description_
+
+        Yields:
+            Generator[str, None, None]: _description_
+        """
+        # If the event_type is not captured by the mappings in event.py
+        # it is not a relevant event
+        if event.event_type is None:
+            return
+        # Initialize the csv line arguments
+        kwargs = dict(
+            zip(
+                ("date", "type", "value", "note", "isin", "shares"),
+                ["" for _ in range(6)],
+            )
+        )
+        
+        # Apply special formatting to value, note, shares and type attributes
+        kwargs["value"] = [event.value] if event.value is not None else [""]
+        kwargs["shares"] = [event.shares] if event.shares is not None else [""]
+        kwargs["note"] = [self.translate(event.note) + " - " + event.title] if event.note is not None else [event.title]
+        kwargs["isin"] = [event.isin] if event.isin is not None else [""]
+        kwargs["type"] = [self.translate(event.event_type.value) if isinstance(event.event_type, PPEventType) else None]
+        kwargs["date"] = [event.date.strftime("%Y-%m-%d")]
+
+        # Handle TRADE_INVOICE
+        if event.event_type == UnprocessedEventType.TRADE_INVOICE:
+            event.event_type = PPEventType.BUY if event.value < 0 else PPEventType.SELL
+            kwargs["type"] = [self.translate(event.event_type.value)]
+
+        # The following three event types generate two or three csv lines per event
+        # (buy+deposit or dividend/interest/sell+tax or buy/sell+fee or sell+tax+fee)
+        additional_events = []
+        # Handle SAVEBACK
+        if event.event_type == UnprocessedEventType.SAVEBACK:
+            kwargs["type"] = [
+                self.translate(PPEventType.BUY.value),
+                self.translate(PPEventType.DEPOSIT.value),
+            ]
+        # Handle Tax
+        if (
+            event.event_type
+            in [PPEventType.DIVIDEND, PPEventType.INTEREST, PPEventType.SELL]
+            and event.tax is not None
+        ):
+            kwargs["value"][0] += event.tax
+            kwargs["type"] += [self.translate(PPEventType.TAXES.value)]
+            kwargs["value"] += [event.tax]
+        # Handle Fee
+        if (
+            event.event_type in [PPEventType.BUY, PPEventType.SELL]
+            and event.fee is not None
+        ):
+            if isinstance(kwargs["value"][0], str): breakpoint()
+            kwargs["value"][0] -= event.fee
+            kwargs["type"] += [self.translate(PPEventType.FEES.value)]
+            kwargs["value"] += [event.fee]
+        
+
+        # Handle float to string conversion after tax and fee effects on the value field
+        if event.value is not None:
+            kwargs["value"] = [format_decimal(
+                value, locale=self.lang, decimal_quantization=True
+            ) for value in kwargs["value"]]
+        if event.shares is not None:
+            kwargs["shares"] = [format_decimal(
+                kwargs["shares"][0], locale=self.lang, decimal_quantization=False
+            )]
+
+        # Build the csv line formatting arguments when one event generates more than one line
+        single_element_dict = {
+            key: value[0] for key, value in kwargs.items() if len(value) == 1
+        }
+        multi_element_dict = {
+            key: value for key, value in kwargs.items() if len(value) > 1
+        }
+        list_kwargs = [dict(zip(multi_element_dict.keys(), v)) for v in zip(*multi_element_dict.values())]
+        for line in list_kwargs:
+            line.update(single_element_dict)
+        # Assert that if one kwargs value has a greater 1 length, 
+        # all greater 1 length lists must have same length
+        assert len(set(map(len, multi_element_dict.values()))) <= 1
+        # Yields csv lines
+        for kwargs in list_kwargs:
+            if "isin" not in kwargs.keys(): breakpoint()
+            yield self.csv_fmt.format(**kwargs)

--- a/pytr/event_formatter.py
+++ b/pytr/event_formatter.py
@@ -1,7 +1,7 @@
 from babel.numbers import format_decimal
 from copy import deepcopy
 
-from .event import Event, PPEventType, UnprocessedEventType
+from .event import Event, PPEventType, ConditionalEventType
 from .translation import setup_translation
 
 
@@ -50,7 +50,7 @@ class EventCsvFormatter:
         )
 
         # Handle TRADE_INVOICE
-        if event.event_type == UnprocessedEventType.TRADE_INVOICE:
+        if event.event_type == ConditionalEventType.TRADE_INVOICE:
             event.event_type = PPEventType.BUY if event.value < 0 else PPEventType.SELL
 
         # Apply special formatting to the attributes
@@ -73,16 +73,16 @@ class EventCsvFormatter:
             )
         if event.fees is not None:
             kwargs["fees"] = format_decimal(
-                event.fees, locale=self.lang, decimal_quantization=True
+                -event.fees, locale=self.lang, decimal_quantization=True
             )
         if event.taxes is not None:
             kwargs["taxes"] = format_decimal(
-                event.taxes, locale=self.lang, decimal_quantization=True
+                -event.taxes, locale=self.lang, decimal_quantization=True
             )
         lines = self.csv_fmt.format(**kwargs)
 
         # Generate BUY and DEPOSIT events from SAVEBACK event
-        if event.event_type == UnprocessedEventType.SAVEBACK:
+        if event.event_type == ConditionalEventType.SAVEBACK:
             kwargs["type"] = self.translate(PPEventType.BUY.value)
             lines = self.csv_fmt.format(**kwargs)
             kwargs["type"] = self.translate(PPEventType.DEPOSIT.value)

--- a/pytr/locale/cs/LC_MESSAGES/messages.po
+++ b/pytr/locale/cs/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Koupit"
 msgid "DEPOSIT"
 msgstr "Vklad"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividendy"
 
 msgid "FEES"

--- a/pytr/locale/da/LC_MESSAGES/messages.po
+++ b/pytr/locale/da/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Køb"
 msgid "DEPOSIT"
 msgstr "Indsæt"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Udbytte"
 
 msgid "FEES"

--- a/pytr/locale/de/LC_MESSAGES/messages.po
+++ b/pytr/locale/de/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Kauf"
 msgid "DEPOSIT"
 msgstr "Einlage"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividende"
 
 msgid "FEES"

--- a/pytr/locale/en/LC_MESSAGES/messages.po
+++ b/pytr/locale/en/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Buy"
 msgid "DEPOSIT"
 msgstr "Deposit"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividend"
 
 msgid "FEES"

--- a/pytr/locale/es/LC_MESSAGES/messages.po
+++ b/pytr/locale/es/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Compra"
 msgid "DEPOSIT"
 msgstr "Depósito"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividendo"
 
 msgid "FEES"

--- a/pytr/locale/fr/LC_MESSAGES/messages.po
+++ b/pytr/locale/fr/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Achat"
 msgid "DEPOSIT"
 msgstr "Dépôt"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividendes"
 
 msgid "FEES"

--- a/pytr/locale/it/LC_MESSAGES/messages.po
+++ b/pytr/locale/it/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Compra"
 msgid "DEPOSIT"
 msgstr "Deposito"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividendo"
 
 msgid "FEES"

--- a/pytr/locale/nl/LC_MESSAGES/messages.po
+++ b/pytr/locale/nl/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Aankoop"
 msgid "DEPOSIT"
 msgstr "Storting"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividend"
 
 msgid "FEES"

--- a/pytr/locale/pl/LC_MESSAGES/messages.po
+++ b/pytr/locale/pl/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Kupno"
 msgid "DEPOSIT"
 msgstr "Depozyt"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dywidenda"
 
 msgid "FEES"

--- a/pytr/locale/pt/LC_MESSAGES/messages.po
+++ b/pytr/locale/pt/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Comprar"
 msgid "DEPOSIT"
 msgstr "Depósito"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividendo"
 
 msgid "FEES"

--- a/pytr/locale/ru/LC_MESSAGES/messages.po
+++ b/pytr/locale/ru/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Покупка"
 msgid "DEPOSIT"
 msgstr "Пополнение"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Дивиденд"
 
 msgid "FEES"

--- a/pytr/locale/sk/LC_MESSAGES/messages.po
+++ b/pytr/locale/sk/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "Kúpiť"
 msgid "DEPOSIT"
 msgstr "Vklad"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "Dividenda"
 
 msgid "FEES"

--- a/pytr/locale/zh/LC_MESSAGES/messages.po
+++ b/pytr/locale/zh/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr "买入"
 msgid "DEPOSIT"
 msgstr "存款"
 
-msgid "DIVIDENDS"
+msgid "DIVIDEND"
 msgstr "股息"
 
 msgid "FEES"

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -52,6 +52,12 @@ def get_main_parser():
     parser_login_args.add_argument('-n', '--phone_no', help='TradeRepublic phone number (international format)')
     parser_login_args.add_argument('-p', '--pin', help='TradeRepublic pin')
 
+    # sort
+    parser_sort_export = argparse.ArgumentParser(add_help=False)
+    parser_sort_export.add_argument(
+        '-s', '--sort', help='Chronologically sort exported csv transactions', action="store_true"
+    )
+
     # login
     info = (
         'Check if credentials file exists. If not create it and ask for input. Try to login.'
@@ -74,7 +80,7 @@ def get_main_parser():
     parser_dl_docs = parser_cmd.add_parser(
         'dl_docs',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        parents=[parser_login_args],
+        parents=[parser_login_args, parser_sort_export],
         help=info,
         description=info,
     )
@@ -141,6 +147,7 @@ def get_main_parser():
     parser_export_transactions = parser_cmd.add_parser(
         'export_transactions',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[parser_sort_export],
         help=info,
         description=info,
     )
@@ -207,6 +214,7 @@ def main():
             since_timestamp=since_timestamp,
             max_workers=args.workers,
             universal_filepath=args.universal,
+            sort_export=args.sort
         )
         asyncio.get_event_loop().run_until_complete(dl.dl_loop())
     elif args.command == 'set_price_alarms':
@@ -222,7 +230,7 @@ def main():
         if args.output is not None:
             p.portfolio_to_csv(args.output)
     elif args.command == 'export_transactions':
-        export_transactions(args.input, args.output, args.lang)
+        export_transactions(args.input, args.output, args.lang, args.sort)
     elif args.version:
         installed_version = version('pytr')
         print(installed_version)

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -172,6 +172,6 @@ class Timeline:
             with open(dl.output_path / 'all_events.json', 'w', encoding='utf-8') as f:
                 json.dump(self.events_without_docs + self.events_with_docs, f, ensure_ascii=False, indent=2)
 
-            export_transactions(dl.output_path / 'all_events.json', dl.output_path / 'account_transactions.csv')
+            export_transactions(dl.output_path / 'all_events.json', dl.output_path / 'account_transactions.csv', sort = dl.sort_export)
 
             dl.work_responses()

--- a/pytr/translation.py
+++ b/pytr/translation.py
@@ -23,5 +23,4 @@ def setup_translation(language="en"):
         "messages", localedir=locale_dir, languages=[language], fallback=True
     )
     lang.install()
-
     return lambda x: lang.gettext(x) if len(x) > 0 else ""


### PR DESCRIPTION
Refactors the parsing of all_events.json and the formatting into all_transactions.csv to capture all pp events generated by tr events, especially taxes, fees, and savebacks.

In detail:
~~1. Removes card_failed_transaction type due to it not being relevant for PP~~
2. Adds INCOMING_TRANSFER_DELEGATION and events from #116 (INTEREST_PAYOUT, card_successful_oct, TAX_REFUND, benefits_saveback_execution) to event.py
3. Introduces enums and dataclasses in event.py to a. structure and facilitate type matching b. differentiate between pp_types and types that require further csv formatting
4. Introduces tax and fee parsers in event.py
5. Introduces event_formatter.py to generate multiple csv lines from certain events (saveback, ~~taxed income, transactions with fees~~). Fees and taxes are added as csv columns to avoid stand-alone transactions.
6. Adds a cli option argument to dl_docs and export_transactions to chronologically sort the exported csv transactions
Additionally:
- Changes DIVIDENDS to DIVIDEND in .po messages to respect PP's nomenclature

The all_events.json available to me parses into an accurate all_transactions.csv; however, I highly encourage everyone to test the pr on their own event logs.
I did not observe breaking changes when testing with the docker image of python 3.8