### PR TITLE
Re-subscribe in case of an error from Trade Republic

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -71,7 +71,9 @@ class DL:
             try:
                 _, subscription, response = await self.tr.recv()
             except TradeRepublicError as e:
-                self.log.fatal(str(e))
+                self.log.error(f"Error response for subscription \"{e.subscription}\". Re-subscribing...")
+                await self.tr.subscribe(e.subscription)
+                continue
 
             if subscription.get("type", "") == "timelineTransactions":
                 await self.tl.get_next_timeline_transactions(response)


### PR DESCRIPTION
Hi,

this should fix an issue that was initially reported in #109.

When downloading large numbers of timeline events, some subscriptions might yield errors. Such as shown in the logs:
`Received error message: '829 E {"errors":[{"errorCode":"UNKNOWN_ERROR","errorField":null,"errorMessage":"Could not process response","meta":{"source":"MAPPER"}}]}'`

I guess formerly it caused the downloading not to return at all. This endless waiting seems to have been fixed in 2f62b098e8e339f8bcfe65177adeb46a6b05efdd. However, this only makes pytr return at the cost of adding some double transactions in the resulting account_transactions.csv while leaving out the transactions where data retrieval from TR failed, because the loop in DL.dl_loop() is not broken up but rather feeded with the previous response.

This should fix it by re-registering failed subscriptions. In my case I now get consistent transaction files when downloading my whole history.