### PR TITLE
Ignore canceled deposits

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -122,6 +122,8 @@ class Event:
                 if event_dict.get("status", "").lower() == "executed"
                 else None
             )
+        elif event_type == PPEventType.DEPOSIT and event_dict.get("status", "").lower() == "canceled":
+            event_type = None
         return event_type
 
     @classmethod

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional, Tuple, Union
 class ConditionalEventType(Enum):
     """Events that conditionally map to None or one/multiple PPEventType events"""
 
-    FAILED_CARD_TRANSACTION = auto()
     SAVEBACK = auto()
     TRADE_INVOICE = auto()
 
@@ -50,7 +49,7 @@ tr_event_type_mapping = {
     "CREDIT": PPEventType.DIVIDEND,
     "ssp_corporate_action_invoice_cash": PPEventType.DIVIDEND,
     # Failed card transactions
-    "card_failed_transaction": ConditionalEventType.FAILED_CARD_TRANSACTION,
+    "card_failed_transaction": PPEventType.REMOVAL,
     # Interests
     "INTEREST_PAYOUT": PPEventType.INTEREST,
     "INTEREST_PAYOUT_CREATED": PPEventType.INTEREST,
@@ -116,13 +115,7 @@ class Event:
         event_type: Optional[EventType] = tr_event_type_mapping.get(
             event_dict.get("eventType", ""), None
         )
-        if event_type == ConditionalEventType.FAILED_CARD_TRANSACTION:
-            event_type = (
-                PPEventType.REMOVAL
-                if event_dict.get("status", "").lower() == "executed"
-                else None
-            )
-        elif event_type == PPEventType.DEPOSIT and event_dict.get("status", "").lower() == "canceled":
+        if event_dict.get("status", "").lower() == "canceled":
             event_type = None
         return event_type
 


### PR DESCRIPTION
It can happen that deposits get canceled. E.g. when you send money from another person's bank account which Trade Republic will reject. In that case, the deposit is canceled and no effective transaction should be created.