### PR TITLE
Set correct project url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 authors = [
     { name = "marzzzello", email = "853485-marzzzello@users.noreply.gitlab.com" }
 ]
-urls = { "Homepage" = "https://gitlab.com/pytr-org/pytr/" }
+urls = { "Homepage" = "https://github.com/pytr-org/pytr" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
The url to the homepage on PyPI points to a repository on Gitlab which apparently does not exist.