### PR TITLE
add option to query account details including personal data

### DIFF
--- a/pytr/accountdetails.py
+++ b/pytr/accountdetails.py
@@ -1,0 +1,16 @@
+import json
+
+class Accountdetails:
+    def __init__(self, tr):
+        self.tr = tr
+        self.data = None
+
+    def get(self):
+        self.data = self.tr.get_account_details()
+        print(f"{self.data}")
+        return self.data
+    
+    def data_to_file(self, output_path):
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(self.data, f)
+    

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -262,6 +262,13 @@ class TradeRepublicApi:
                 return True
         return False
 
+    def get_account_details(self):
+        r = self._websession.get(
+            f"{self._host}/api/v2/auth/account",
+        )
+        j = r.json()
+        return j
+
     def _web_request(self, url_path, payload=None, method="GET"):
         if self._web_session_token_expires_at < time.time():
             r = self._websession.get(f"{self._host}/api/v1/auth/web/session")

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -17,6 +17,7 @@ from pytr.account import login
 from pytr.portfolio import Portfolio
 from pytr.alarms import Alarms
 from pytr.details import Details
+from pytr.accountdetails import Accountdetails
 
 
 def get_main_parser():
@@ -200,6 +201,18 @@ def get_main_parser():
         help='Two letter language code or "auto" for system language',
         default="auto",
     )
+    # account details
+    info = "Show account details"
+    parser_accountdetails = parser_cmd.add_parser(
+        "accountdetails",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[parser_login_args],
+        help=info,
+        description=info,
+    )
+    parser_accountdetails.add_argument(
+        "-j", "--jsonoutput", help="Output path of JSON file", metavar="OUTPUT", type=Path
+    )
 
     info = "Print shell tab completion"
     parser_completion = parser_cmd.add_parser(
@@ -287,6 +300,13 @@ def main():
         installed_version = version("pytr")
         print(installed_version)
         check_version(installed_version)
+    elif args.command == "accountdetails":
+        ad = Accountdetails(
+            login(phone_no=args.phone_no, pin=args.pin, web=not args.applogin),
+        )
+        ad.get()
+        if args.jsonoutput is not None:
+            ad.data_to_file(args.jsonoutput)
     else:
         parser.print_help()
 


### PR DESCRIPTION
The API so far does not read the account data from Traderepublic. A lot of this data is not that interesting and pretty static (name, address, etc). But there is also the main account including IBAN.

I need this for my own asset management application where I aggregate all the current/saving accounts from all my banks. To achieve this I added modules for each bank, they send the account information to the main app. Thus only the balance is not enough, at least IBAN is needed to sort things out for the main app.

I'm aware that returning the dict and writing out the JSON is not that much of a processing. Please consider adding this "anyway", change the code or tell me what I should add.

Addmittedly I'm pretty new to Python. 

This is roughly what you will get:
```json
{
	"phoneNumber":"+491xxxx",
	"jurisdiction":"DE",
	"name":{"first":"xxxx", "last":"xxx"},
	"email":{"address":"xxxx@xxxx.de", "verified":true},
	"duplicateTradingEmail":null,
	"postalAddress":{"street":"SomeStreet", "houseNo":"4", "zip":"123456", "city":"Somecity", "country":"DE"},
	"birthdate":"1902-01-01",
	"birthplace":{"birthplace":"Somecity", "birthcountry":"DE"},
	"mainNationality":"DE",
	"additionalNationalities":[],
	"mainTaxResidency":{"tin":"12345987", "countryCode":"DE"},
	"usTaxResidency":false,
	"additionalTaxResidencies":[],
	"taxInformationSyncTimestamp":172177300000,
	"taxExemptionOrder":{"minimum":0, "maximum":9900, "current":111, "applied":2131, "syncStatus":12414, "validFrom":1242, "validUntil":2312}, 
	"registrationAccount":false,
	"cashAccount":{"iban":"DE00000000000000000000", "bic":"TRBKDEBBXXX", "bankName":"J.P. Morgan SE", "logoUrl":null},
	"referenceAccount":{"iban":"-", "bic":null},
	"referenceAccountV2":null,
	"referenceAccountList":[{"iban":"DE00012134874564878747", "bic":null, "bankName":"Bank", "logoUrl":"logos/bank_bank/v2"}],
	"securitiesAccountNumber":"321354657",
	"experience":{"stock":{"tradeCount":0, "level":"LOSER", "showsRiskWarning":true},
	"fund":{"tradeCount":0, "level":"LOSER", "showsRiskWarning":true},
	"derivative":{"tradeCount":0, "level":"LOSER", "showsRiskWarning":true},
	"crypto":{"tradeCount":100, "level":"GODMODE", "showsRiskWarning":true},
	"bond":{"level":"xxxx", "showsRiskWarning":true}},
	"referralDetails":null,
	"supportDocuments":{
	   "accountClosing":"https://assets.traderepublic.com/assets/files/foilename.pdf",
	   "imprint":"https://traderepublic.com/de-de/imprint",
	   "addressConfirmation":"https://support.traderepublic.com/de-de/102"},
	   "tinFormat":{"placeholder":"99999999999",
	   "keyboardLayout":"numerical"
	},
	"personId":"babdbddb-5441-23-124-423423542532112"
}
```