### PR TITLE
Ignore unsupported Timeline events and log them

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -8,7 +8,7 @@ from pathvalidate import sanitize_filepath
 
 from pytr.utils import preview, get_logger
 from pytr.api import TradeRepublicError
-from pytr.timeline import Timeline
+from pytr.timeline import Timeline, UnsupportedEventError
 
 
 class DL:
@@ -82,7 +82,10 @@ class DL:
             elif subscription.get("type", "") == "timelineActivityLog":
                 await self.tl.get_next_timeline_activity_log(response)
             elif subscription.get("type", "") == "timelineDetailV2":
-                await self.tl.process_timelineDetail(response, self)
+                try:
+                    self.tl.process_timelineDetail(response, self)
+                except UnsupportedEventError:
+                    self.log.warning("Ignoring unsupported event %s", response)
             else:
                 self.log.warning(
                     f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}"

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -5,6 +5,10 @@ from .utils import get_logger
 from .transactions import export_transactions
 
 
+class UnsupportedEventError(Exception):
+    pass
+
+
 class Timeline:
     def __init__(self, tr, max_age_timestamp):
         self.tr = tr
@@ -119,15 +123,18 @@ class Timeline:
         self.log.info("All timeline details requested")
         return False
 
-    async def process_timelineDetail(self, response, dl):
+    def process_timelineDetail(self, response, dl):
         """
         process timeline details response
         download any associated docs
         create other_events.json, events_with_documents.json and account_transactions.csv
         """
 
+        event = self.timeline_events.get(response["id"], None)
+        if event is None:
+            raise UnsupportedEventError(response["id"])
+
         self.received_detail += 1
-        event = self.timeline_events[response["id"]]
         event["details"] = response
 
         max_details_digits = len(str(self.requested_detail))


### PR DESCRIPTION
The Christmas Gift event was causing errors, see

* https://github.com/pytr-org/pytr/issues/148
* https://github.com/pytr-org/pytr/issues/151

There might be a sensible way to handle this event, but before that I think it makes sense to make it so the `dl_docs` command doesn't outright crash when there's an unsupported event in the timeline.

Inspired largely by @zonefuenf (https://github.com/pytr-org/pytr/issues/148#issuecomment-2532089877)