### PR TITLE
Fix: Handle skipped timeline details properly to avoid script getting stuck with UnsupportedEventError

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -86,6 +86,8 @@ class DL:
                     self.tl.process_timelineDetail(response, self)
                 except UnsupportedEventError:
                     self.log.warning("Ignoring unsupported event %s", response)
+                    self.tl.skipped_detail += 1
+                    self.tl.check_if_done(self)
             else:
                 self.log.warning(
                     f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}"


### PR DESCRIPTION
Thanks to **@NiklasRosenstein** and **@zonefuenf** for their work on [#161](https://github.com/pytr-org/pytr/pull/161), which introduced support for `UnsupportedEventError` to handle Trade Republic’s Christmas Gift event. While this resolved the initial issue, a new problem emerged: when an `UnsupportedEventError` occurs, the `received_detail` counter does not increment. This prevents the termination condition `received_detail == requested_detail` from ever being met, causing the `dl_docs` script to hang and PDFs to not be stored in the folder. Consequently, the issue with the script not finishing and thus not outputting any of the PDF files still persists.

**What This PR Does**  
- **Introduces a `skipped_detail` counter** to track events that trigger `UnsupportedEventError`.  
- **Updates the termination condition** to `(received_detail + skipped_detail) == requested_detail`, ensuring the script can terminate properly even when unsupported events are present.  
- **Handles the edge case** where the last event is unsupported by checking the termination condition after raising `UnsupportedEventError`.  
- **Logs an additional warning** at the end of execution if any events were skipped, informing users about the unsupported events encountered, which might be overlooked if a lot of transactions followed the warning.

**Current Issue Addressed**  
- **Script Hanging:** Without incrementing `received_detail` (or like proposed here the `skipped_detail`) for unsupported events, the script remains stuck (e.g., at 148/150), preventing completion and storage of PDFs.
- **Final Event Problem:** If the last event is unsupported, the script raises `UnsupportedEventError` before evaluating the termination condition, preventing the script from finalizing.

**Credits**
- **@zonefuenf** for the original idea ([#148 (comment)](https://github.com/pytr-org/pytr/issues/148#issuecomment-2532089877)).
- **@NiklasRosenstein** for the implementation in [#161](https://github.com/pytr-org/pytr/pull/161).