### PR TITLE
Run Pytest in CI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,9 +5,22 @@ on:
   - workflow_dispatch
 
 jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.21"
+      - name: Pytest
+        run: uv run pytest
+
   build-n-publish:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
+    needs: checks
     steps:
       - uses: actions/checkout@master
       - name: Install uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ pytr = "pytr.main:main"
 
 [tool.hatch.build.hooks.babel]
 locale_dir = "pytr/locale"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+]


### PR DESCRIPTION
This PR makes it so Pytest is run before the `build-n-publish` CI job.