### PR TITLE
Fix missing date in filename

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -93,7 +93,7 @@ class DL:
                     f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}"
                 )
 
-    def dl_doc(self, doc, titleText, subtitleText, subfolder=None):
+    def dl_doc(self, doc, titleText, subtitleText, subfolder=None, timestamp=None):
         """
         send asynchronous request, append future with filepath to self.futures
         """
@@ -105,8 +105,12 @@ class DL:
             date = doc["detail"]
             iso_date = "-".join(date.split(".")[::-1])
         except KeyError:
-            date = ""
-            iso_date = ""
+            if timestamp:
+                date = timestamp.strftime("%d.%m.%Y")
+                iso_date = timestamp.strftime("%Y-%m-%d")
+            else:
+                date = ""
+                iso_date = ""
         doc_id = doc["id"]
 
         # extract time from subtitleText

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -171,7 +171,8 @@ class Timeline:
                         "CREDIT",
                     ]:
                         title += f" - {event['subtitle']}"
-                    dl.dl_doc(doc, title, doc.get("detail"), subfolder)
+                    dl.dl_doc(doc, title, doc.get("detail"), subfolder,
+                              datetime.fromisoformat(event['timestamp']))
 
         if event["has_docs"]:
             self.events_with_docs.append(event)


### PR DESCRIPTION
Problem: Downloaded documents are sometimes missing the date in the file name. This is caused by `doc['detail']` not containing a date string.

Fix: If `doc['detail']` does not contain a date, it uses the time from `event['timestamp']`.

This also fixes #137 