### PR TITLE
Run CI on Pull Requests

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,10 +1,11 @@
 name: Build and publish Python distributions to PyPI
 
 on:
-  - push:
-      branches: ["master"]
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches: [ 'master' ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
 
 jobs:
   checks:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,7 +1,8 @@
 name: Build and publish Python distributions to PyPI
 
 on:
-  - push
+  - push:
+      branches: ["master"]
   - pull_request
   - workflow_dispatch
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,7 @@ name: Build and publish Python distributions to PyPI
 
 on:
   - push
+  - pull_request
   - workflow_dispatch
 
 jobs:

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -165,8 +165,7 @@ class Timeline:
                         "CREDIT",
                     ]:
                         title += f" - {event['subtitle']}"
-                    dl.dl_doc(doc, title, doc.get("detail"), subfolder,
-                              datetime.fromisoformat(event['timestamp']))
+                    dl.dl_doc(doc, title, doc.get("detail"), subfolder, datetime.fromisoformat(event["timestamp"]))
 
         if event["has_docs"]:
             self.events_with_docs.append(event)


### PR DESCRIPTION
Update the `on` configuration of the workflow:

- Trigger on pushes to the main branch (`master`)
- Trigger on any pull requests
- Remove `workflow_dispatch` trigger (it appears to be unused)