### PR TITLE
Add a `--date-isoformat` option to `pytr export_transactions`

### DIFF
--- a/pytr/main.py
+++ b/pytr/main.py
@@ -193,6 +193,11 @@ def get_main_parser():
         help='Two letter language code or "auto" for system language',
         default="auto",
     )
+    parser_export_transactions.add_argument(
+        "--date-isoformat",
+        help="Format the date column in ISO8601 including the time.",
+        action="store_true",
+    )
 
     info = "Print shell tab completion"
     parser_completion = parser_cmd.add_parser(
@@ -300,7 +305,7 @@ def main():
         if args.output is not None:
             p.portfolio_to_csv(args.output)
     elif args.command == "export_transactions":
-        export_transactions(args.input, args.output, args.lang, args.sort)
+        export_transactions(args.input, args.output, args.lang, args.sort, args.date_isoformat)
     elif args.version:
         installed_version = version("pytr")
         print(installed_version)

--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -6,7 +6,7 @@ from .event_formatter import EventCsvFormatter
 from .utils import get_logger
 
 
-def export_transactions(input_path, output_path, lang="auto", sort=False):
+def export_transactions(input_path, output_path, lang="auto", sort=False, date_isoformat: bool = False):
     """
     Create a CSV with the deposits and removals ready for importing into Portfolio Performance
     The CSV headers for PP are language dependend
@@ -43,6 +43,8 @@ def export_transactions(input_path, output_path, lang="auto", sort=False):
     log.info("Write deposit entries")
 
     formatter = EventCsvFormatter(lang=lang)
+    if date_isoformat:
+        formatter.date_fmt = "ISO8601"
 
     events = map(lambda x: Event.from_dict(x), timeline)
     if sort:


### PR DESCRIPTION
With the new `pytr export_transactions --date-isoformat` option, the date column is formatted in ISO-8601 including the timestamp.

```csv
Date;Type;Value;Note;ISIN;Shares;Fees;Taxes
2025-02-01T06:55:39;Interest;24.52;Zinsen;;;;-878
2024-12-01T16:09:19;Interest;6.53;Zinsen;;;;
```

Closes #165 