### PR TITLE
Upgrade PyPI publish version from v1.9 to v1 (i.e. using the latest in the major version 1)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -38,6 +38,6 @@ jobs:
         run: uv build
       - name: Publish distribution to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1.9
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
This is necessary because unfortunately the version that was pinned did not support Python package metadata version 2.4, which is the version that `uv build` with Hatchling produced.

```
Metadata-Version: 2.4
Name: pytr
Version: 0.4.0
Summary: Use TradeRepublic in terminal
...
```

This made the release job for 0.4.0 fail, unfortunately. 