### PR TITLE
Map `PAYMENT_INBOUND_CREDIT_CARD` transaction and parse fees for deposits/removals

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -44,6 +44,7 @@ tr_event_type_mapping = {
     "PAYMENT_INBOUND_APPLE_PAY": PPEventType.DEPOSIT,
     "PAYMENT_INBOUND_GOOGLE_PAY": PPEventType.DEPOSIT,
     "PAYMENT_INBOUND_SEPA_DIRECT_DEBIT": PPEventType.DEPOSIT,
+    "PAYMENT_INBOUND_CREDIT_CARD": PPEventType.DEPOSIT,
     "card_refund": PPEventType.DEPOSIT,
     "card_successful_oct": PPEventType.DEPOSIT,
     "card_tr_refund": PPEventType.DEPOSIT,
@@ -142,6 +143,7 @@ class Event:
             taxes = cls._parse_taxes(event_dict)
 
         elif event_type in [PPEventType.DEPOSIT, PPEventType.REMOVAL]:
+            shares, fees = cls._parse_shares_and_fees(event_dict)
             note = cls._parse_card_note(event_dict)
 
         return fees, isin, note, shares, taxes

--- a/tests/sample_credit_card_deposit.json
+++ b/tests/sample_credit_card_deposit.json
@@ -1,0 +1,141 @@
+{
+    "id": "5b04b073-c06f-4ab1-bd01-de51b56162dc",
+    "timestamp": "2022-08-27T05:06:30.471+0000",
+    "title": "Einzahlung",
+    "icon": "logos/bank_mastercard/v2",
+    "badge": null,
+    "subtitle": null,
+    "amount": {
+        "currency": "EUR",
+        "value": 1000.0,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "5b04b073-c06f-4ab1-bd01-de51b56162dc"
+    },
+    "eventType": "PAYMENT_INBOUND_CREDIT_CARD",
+    "cashAccountNumber": null,
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "5b04b073-c06f-4ab1-bd01-de51b56162dc",
+        "sections": [
+            {
+                "title": "Du hast 1.000,00 € über Kreditkarte hinzugefügt",
+                "data": {
+                    "icon": "logos/bank_mastercard/v2",
+                    "subtitleText": null,
+                    "timestamp": "2022-08-27T05:06:30.471+0000",
+                    "status": "executed"
+                },
+                "action": null,
+                "type": "header"
+            },
+            {
+                "title": "Übersicht",
+                "data": [
+                    {
+                        "title": "Status",
+                        "detail": {
+                            "text": "Completed",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Zahlung",
+                        "detail": {
+                            "text": "·· 7431",
+                            "icon": "logos/bank_mastercard/v2",
+                            "type": "iconWithText"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "action": null,
+                "type": "table"
+            },
+            {
+                "title": "Transaktion",
+                "data": [
+                    {
+                        "title": "Gebühr",
+                        "detail": {
+                            "text": "7,00 €",
+                            "trend": null,
+                            "action": null,
+                            "displayValue": null,
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Betrag",
+                        "detail": {
+                            "text": "1.000,00 €",
+                            "trend": null,
+                            "action": null,
+                            "displayValue": null,
+                            "type": "text"
+                        },
+                        "style": "highlighted"
+                    }
+                ],
+                "action": null,
+                "type": "table"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Abrechnung Einzahlung",
+                        "detail": "27.08.2022",
+                        "action": {
+                            "type": "browserModal",
+                            "payload": "https://traderepublic-data-production.s3.eu-central-1.amazonaws.com/timeline/postbox/2022/8/27/51850145/pb16615767906502642694118463234.pdf?REDACTED"
+                        },
+                        "id": "4f6f159f-08f1-4573-9b69-2418d57ca37a",
+                        "postboxType": "PAYMENT_INBOUND_INVOICE",
+                        "local_filepath": "out/Abrechnung Einzahlung/2022-08-27 Abrechnung Einzahlung - Einzahlung.pdf"
+                    }
+                ],
+                "action": null,
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "",
+                            "action": {
+                                "type": "customerSupportChat",
+                                "payload": {
+                                    "contextParams": {
+                                        "chat_flow_key": "NHC_0024_deposit_report_an_issue",
+                                        "timelineEventId": "5b04b073-c06f-4ab1-bd01-de51b56162dc",
+                                        "createdAt": "2022-08-27T05:06:30.505105Z",
+                                        "amount": "1000.000000"
+                                    },
+                                    "contextCategory": "NHC"
+                                }
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "action": null,
+                "type": "table"
+            }
+        ]
+    },
+    "has_docs": true
+}

--- a/tests/test_event_csv_formatter.py
+++ b/tests/test_event_csv_formatter.py
@@ -38,3 +38,14 @@ def test_buy():
 
     # Assert that the output is not an empty string
     assert csv_output == "2024-02-20;Kauf;-3.002,8;Euro Stoxx 50 EUR (Dist);IE00B4K6B022;60;-1;\n"
+
+
+def test_credit_card_deposit() -> None:
+    with open("tests/sample_credit_card_deposit.json") as file:
+        sample_data = json.load(file)
+
+    event = Event.from_dict(sample_data)
+    formatter = EventCsvFormatter(lang="en")
+    csv_output = formatter.format(event)
+
+    assert csv_output == "2022-08-27;Deposit;1,000;Einzahlung;;;-7;\n"


### PR DESCRIPTION
We missed mapping the `PAYMENT_INBOUND_CREDIT_CARD` transaction type, and deposits via credit card or Google Pay, etc. can have fees attached to them that we did not parse.

