### PR TITLE
Ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ cython_debug/
 
 # VSCode
 .vscode/**
+
+# uv
+uv.lock


### PR DESCRIPTION
This file gets created on my Windows. Should be ignored for git.