### PR TITLE
Fix dl_docs command

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -94,35 +94,18 @@ class DL:
             else:
                 self.log.warning(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
-    def dl_doc(self, doc, titleText, subtitleText, subfolder=None, timestamp=None):
+    def dl_doc(self, doc, titleText, subfolder, doc_date):
         """
         send asynchronous request, append future with filepath to self.futures
         """
         doc_url = doc["action"]["payload"]
+        subtitleText = doc.get("detail")
         if subtitleText is None:
             subtitleText = ""
 
-        try:
-            date = doc["detail"]
-            iso_date = "-".join(date.split(".")[::-1])
-        except KeyError:
-            if timestamp:
-                date = timestamp.strftime("%d.%m.%Y")
-                iso_date = timestamp.strftime("%Y-%m-%d")
-            else:
-                date = ""
-                iso_date = ""
         doc_id = doc["id"]
-
-        # extract time from subtitleText
-        try:
-            time = re.findall("um (\\d+:\\d+) Uhr", subtitleText)
-            if time == []:
-                time = ""
-            else:
-                time = f" {time[0]}"
-        except TypeError:
-            time = ""
+        iso_date = doc_date.strftime("%Y-%m-%d")
+        time = doc_date.strftime("%H:%M")
 
         if subfolder is not None:
             directory = self.output_path / subfolder
@@ -132,11 +115,13 @@ class DL:
         # If doc_type is something like 'Kosteninformation 2', then strip the 2 and save it in doc_type_num
         doc_type = doc["title"].rsplit(" ")
         if doc_type[-1].isnumeric() is True:
-            doc_type_num = f" {doc_type.pop()}"
+            doc_type_num = doc_type.pop()
         else:
             doc_type_num = ""
 
         doc_type = " ".join(doc_type)
+        if doc_type == "Abrechnung Ausführung" or doc_type == "Abrechnungsausführung":
+            doc_type = "Abrechnung"
         titleText = titleText.replace("\n", "").replace("/", "-")
         subtitleText = subtitleText.replace("\n", "").replace("/", "-")
 

--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -1,4 +1,3 @@
-import re
 from concurrent.futures import as_completed
 from pathlib import Path
 

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -109,6 +109,7 @@ events_known_ignored = [
     "VERIFICATION_TRANSFER_ACCEPTED",
     "card_failed_verification",
     "card_successful_verification",
+    "crypto_annual_statement",
     "current_account_activated",
     "new_tr_iban",
     "trading_order_cancelled",

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -156,9 +156,9 @@ def get_main_parser():
     parser_dl_docs.add_argument("output", help="Output directory", metavar="PATH", type=Path)
     parser_dl_docs.add_argument(
         "--format",
-        help="available variables:\tiso_date, time, title, doc_num, subtitle, id",
+        help="available variables:\tiso_date, time, title, subtitle, doc_num, id",
         metavar="FORMAT_STRING",
-        default="{iso_date}{time} {title}{doc_num}",
+        default="{iso_date} {time} {title}",
     )
     parser_dl_docs.add_argument(
         "--last_days",

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -186,11 +186,11 @@ class Timeline:
 
             for doc in section["data"]:
                 timestamp_str = event["timestamp"]
-                if timestamp_str[-3] != ':':
-                    timestamp_str = timestamp_str[:-2] + ':' + timestamp_str[-2:]
+                if timestamp_str[-3] != ":":
+                    timestamp_str = timestamp_str[:-2] + ":" + timestamp_str[-2:]
                 try:
                     docdate = datetime.fromisoformat(timestamp_str)
-                except (ValueError):
+                except ValueError:
                     print(f"no timestamp parseable from {timestamp_str}")
                     docdate = datetime.now()
 


### PR DESCRIPTION
Due to recent changes in responses from the TR API, documents sections of TR data might not contain "detail" entries any more. These were used to get document timestamps from.

With this change we don't use the "detail" field any more for timestamps but solely rely on the event timestamp. Should anyone see issues with that, e.g. wrong document timestamps, please report this and we might consider looking for "detail" in certain cases.

This change also cleans up the subfolder structure for downloaded documents and tries to improve document naming. Please also report issues/regressions.

Should fix #206 