### PR TITLE
fix: report corrected fractional amounts for savings plans and report price

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -273,7 +273,7 @@ class Event:
                 shares = cls._parse_float_from_detail(shares_dict, dump_dict, pref_locale)
                 break
 
-            price_dicts = filter(lambda x: x["title"] in ["Aktienkurs"], data)
+            price_dicts = filter(lambda x: x["title"] in ["Aktienkurs", "Anteilspreis"], data)
             for price_dict in price_dicts:
                 price = cls._parse_float_from_detail(price_dict, dump_dict)
 

--- a/pytr/locale/de/LC_MESSAGES/messages.po
+++ b/pytr/locale/de/LC_MESSAGES/messages.po
@@ -112,6 +112,9 @@ msgstr "Stück"
 msgid "CSVColumn_Taxes"
 msgstr "Steuern"
 
+msgid "CSVColumn_Price"
+msgstr "Preis"
+
 msgid "CSVColumn_TickerSymbol"
 msgstr "Ticker-Symbol"
 

--- a/pytr/locale/en/LC_MESSAGES/messages.po
+++ b/pytr/locale/en/LC_MESSAGES/messages.po
@@ -112,6 +112,9 @@ msgstr "Shares"
 msgid "CSVColumn_Taxes"
 msgstr "Taxes"
 
+msgid "CSVColumn_Price"
+msgstr "Price"
+
 msgid "CSVColumn_TickerSymbol"
 msgstr "Ticker Symbol"
 

--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -35,6 +35,7 @@ CSVCOLUMN_TO_TRANSLATION_KEY = {
     "shares": "CSVColumn_Shares",
     "fees": "CSVColumn_Fees",
     "taxes": "CSVColumn_Taxes",
+    "price": "CSVColumn_Price",
 }
 
 
@@ -113,6 +114,7 @@ class TransactionExporter:
         - `shares`
         - `fees`
         - `taxes`
+        - `price`
         """
 
         if event.event_type is None:
@@ -131,6 +133,7 @@ class TransactionExporter:
             "shares": self._decimal_format(event.shares, False),
             "fees": self._decimal_format(-event.fees) if event.fees is not None else None,
             "taxes": self._decimal_format(-event.taxes) if event.taxes is not None else None,
+            "price": self._decimal_format(event.price) if event.price is not None else None,
         }
 
         # Special case for saveback events. Example payload: https://github.com/pytr-org/pytr/issues/116#issuecomment-2377491990

--- a/tests/sample_buy.json
+++ b/tests/sample_buy.json
@@ -7,7 +7,7 @@
     "subtitle": "Kauforder",
     "amount": {
       "currency": "EUR",
-      "value": -3002.8,
+      "value": -3002.80005,
       "fractionDigits": 2
     },
     "subAmount": null,

--- a/tests/test_event_csv_formatter.py
+++ b/tests/test_event_csv_formatter.py
@@ -29,6 +29,7 @@ def test_event_csv_formatter():
             "Stück": None,
             "Typ": "Einlage",
             "Wert": 3000.0,
+            "Preis": None,
         }
     ]
 
@@ -58,5 +59,6 @@ def test_buy():
             "Stück": 60.0,
             "Typ": "Kauf",
             "Wert": -3002.8,
+            "Preis": 50.03,
         }
     ]


### PR DESCRIPTION
The API response from TR will contain floating point errors for saving plans when fractional shares are bought. The transaction report as well as the PDF report do not contain this error.

For now paper over this deficiency by reporting the total amount from the transaction details instead in those cases.

Example from my actual output:
```
    "amount": {
      "currency": "EUR",
      "value": -499.999874,
      "fractionDigits": 2
    },
```

Additionally, this also reports the price of the bought instrument. This serves as additional help to verify the correct amounts when importing into for example gnucash.