### PR TITLE
Fix dividends on knock-outs

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -252,6 +252,7 @@ class Event:
             if event_type is PPEventType.DIVIDEND:
                 isin = cls._parse_isin(event_dict)
                 taxes = cls._parse_taxes(event_dict)
+                shares, _, _, _ = cls._parse_shares_fees_taxes_and_value(event_dict)
 
             elif event_type is PPEventType.INTEREST:
                 taxes = cls._parse_taxes(event_dict)
@@ -280,6 +281,11 @@ class Event:
             action = section.get("action", None)
             if action and action.get("type", {}) == "instrumentDetail":
                 isin2 = section.get("action", {}).get("payload")
+                break
+            if section.get("type", {}) == "header":
+                isin2 = section.get("data", {}).get("icon")
+                isin2 = isin2[isin2.find("/") + 1 :]
+                isin2 = isin2[: isin2.find("/")]
                 break
         if isin != isin2:
             isin = isin2
@@ -327,6 +333,8 @@ class Event:
                         taxes_dict = item
                     elif title == "Gesamt":
                         gesamt_dict = item
+                    elif title == "Aktien entfernt":
+                        shares_dict = item
                     elif title == "Transaktion":
                         transaction_dict = item
                         detail = item.get("detail", {})

--- a/tests/sample_sell_dividend.json
+++ b/tests/sample_sell_dividend.json
@@ -1,0 +1,172 @@
+{
+  "id": "32a408dd-5d8e-4991-a7c3-0b2fd1dc062c",
+  "timestamp": "2025-01-10T10:00:00.000+0000",
+  "title": "Long 1,2345 $",
+  "icon": "logos/GB00B6398765/v2",
+  "badge": null,
+  "subtitle": "Tilgung",
+  "amount": {
+    "currency": "EUR",
+    "value": 0.1,
+    "fractionDigits": 2
+  },
+  "subAmount": null,
+  "status": "EXECUTED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "32a408dd-5d8e-4991-a7c3-0b2fd1dc062c"
+  },
+  "eventType": "ssp_corporate_action_invoice_cash",
+  "cashAccountNumber": "0123456789",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineTransaction",
+  "details": {
+    "id": "32a408dd-5d8e-4991-a7c3-0b2fd1dc062c",
+    "sections": [
+      {
+        "title": "Du hast 0,10 € erhalten",
+        "data": {
+          "icon": "logos/DE000SX12345/v2",
+          "subtitleText": null,
+          "timestamp": "2025-01-10T10:00:00.000+0000",
+          "status": "executed"
+        },
+        "action": null,
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Status",
+            "detail": {
+              "text": "Ausgeführt",
+              "functionalStyle": "EXECUTED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Event",
+            "detail": {
+              "text": "Tilgung",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Wertpapier",
+            "detail": {
+              "text": "Long @1,2345",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Aktien entfernt",
+            "detail": {
+              "text": "100.000000",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "action": null,
+        "type": "table"
+      },
+      {
+        "title": "Geschäft",
+        "data": [
+          {
+            "title": "Bruttoertrag",
+            "detail": {
+              "text": "0,10 €",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Steuer",
+            "detail": {
+              "text": "0,00 €",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Gesamt",
+            "detail": {
+              "text": "0,10 €",
+              "trend": null,
+              "action": null,
+              "displayValue": null,
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "action": null,
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Dokumente",
+            "detail": "10.05.2025",
+            "action": {
+              "type": "browserModal",
+              "payload": "https://traderepublic-postbox-platform-production.s3.eu-central-1.amazonaws.com/"
+            },
+            "id": "75aa8fe4-cec5-4963-bf8a-2f5aec65c4f5",
+            "postboxType": "CA_INCOME_SECURITIES_INVOICE"
+          }
+        ],
+        "action": null,
+        "type": "documents"
+      },
+      {
+        "title": "",
+        "data": [
+          {
+            "title": "",
+            "detail": {
+              "icon": "common_empty_string",
+              "action": {
+                "type": "customerSupportChat",
+                "payload": {
+                  "contextParams": {
+                    "timelineEventId": "75c154a8-d171-445a-ac87-174513cf58ee",
+                    "chat_flow_key": "NHC_0029_wealth_general_question_corporate_action"
+                  },
+                  "contextCategory": "NHC"
+                }
+              },
+              "style": "highlighted",
+              "type": "listItemAvatarDefault"
+            },
+            "style": "highlighted"
+          }
+        ],
+        "action": null,
+        "type": "table"
+      }
+    ]
+  }
+}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -96,3 +96,18 @@ def test_new_removal_from_dict():
     # Assert the expected values
     assert event.event_type == PPEventType.REMOVAL
     assert event.value == -750
+
+
+def test_dividend_sell_event_from_dict():
+    # Load the sample JSON file
+    with open("tests/sample_sell_dividend.json", "r") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.DIVIDEND
+    assert event.value == 0.1
+    assert event.shares == 100
+    assert event.isin == "DE000SX12345"


### PR DESCRIPTION
On (knockout-)options, before this it would assign the ISIN of the underlying instrument instead of the ISIN of the option itself and the amount of options was also missing.

If you want I can also craft a testcase for this.