### PR TITLE
Improve portfolio listing: optional inclusion of watchlist, more sorting and output options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Investment",
 ]
 dependencies = [
+    "babel",
     "certifi",
     "coloredlogs",
     "ecdsa",
@@ -31,7 +32,6 @@ dependencies = [
     "requests_futures",
     "shtab",
     "websockets>=14",
-    "babel",
 ]
 
 [project.scripts]
@@ -57,4 +57,4 @@ line-length = 120
 extend-select = ["I"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -1,7 +1,37 @@
 import asyncio
+import locale
 import re
+from decimal import ROUND_HALF_UP, Decimal
+from locale import getdefaultlocale
+from typing import Optional, Union
 
-from pytr.utils import preview
+from babel.numbers import format_decimal
+
+from .utils import get_logger, preview
+
+SUPPORTED_LANGUAGES = {
+    "cs",
+    "da",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "nl",
+    "pl",
+    "pt",
+    "ru",
+    "zh",
+}
+
+PORTFOLIO_COLUMNS = {
+    "Name",
+    "ISIN",
+    "quantity",
+    "price",
+    "avgCost",
+    "netValue",
+}
 
 bond_pattern = re.compile(
     r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December|Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\.?\s+20\d{2}",
@@ -10,8 +40,47 @@ bond_pattern = re.compile(
 
 
 class Portfolio:
-    def __init__(self, tr):
+    def __init__(
+        self,
+        tr,
+        include_watchlist=False,
+        lang="en",
+        decimal_localization=False,
+        output=None,
+        sort_by_column=None,
+        sort_descending=True,
+    ):
         self.tr = tr
+        self.include_watchlist = include_watchlist
+        self.lang = lang
+        self.decimal_localization = decimal_localization
+        self.output = output
+        self.sort_by_column = sort_by_column
+        self.sort_descending = sort_descending
+
+        self.watchlist = None
+
+        self._log = get_logger(__name__)
+
+        if self.lang == "auto":
+            locale = getdefaultlocale()[0]
+            if locale is None:
+                self.lang = "en"
+            else:
+                self.lang = locale.split("_")[0]
+
+        if self.lang not in SUPPORTED_LANGUAGES:
+            self._log.info(f'Language not yet supported "{self.lang}", defaulting to "en"')
+            self.lang = "en"
+
+    def _decimal_format(self, value: Optional[float], precision: int = 2) -> Union[str, None]:
+        if value is None:
+            return None
+        if self.decimal_localization:
+            format = "#,##0." + ("#" * precision)
+            return format_decimal(value, format=format, locale=self.lang)
+        else:
+            return f"{float(value):.{precision}f}".rstrip("0").rstrip(".")
 
     async def portfolio_loop(self):
         recv = 0
@@ -19,27 +88,44 @@ class Portfolio:
         recv += 1
         await self.tr.cash()
         recv += 1
+        if self.include_watchlist:
+            await self.tr.watchlist()
+            recv += 1
 
         while recv > 0:
             subscription_id, subscription, response = await self.tr.recv()
 
             if subscription["type"] == "compactPortfolio":
                 recv -= 1
-                self.portfolio = response
+                self.portfolio = response["positions"]
             elif subscription["type"] == "cash":
                 recv -= 1
                 self.cash = response
+            elif subscription["type"] == "watchlist":
+                recv -= 1
+                self.watchlist = response
             else:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
             await self.tr.unsubscribe(subscription_id)
 
+        isins = set()
+        for pos in self.portfolio:
+            isins.add(pos["instrumentId"])
+
+        # extend portfolio with watchlist elements
+        if self.watchlist:
+            for pos in self.watchlist:
+                isin = pos["instrumentId"]
+                if isin not in isins:
+                    isins.add(isin)
+                    self.portfolio.append(pos)
+
         # Populate name for each ISIN
         subscriptions = {}
-        positions = self.portfolio["positions"]
-        for pos in sorted(positions, key=lambda x: x["netSize"], reverse=True):
+        for pos in self.portfolio:
             isin = pos["instrumentId"]
-            subscription_id = await self.tr.instrument_details(pos["instrumentId"])
+            subscription_id = await self.tr.instrument_details(isin)
             subscriptions[subscription_id] = pos
 
         while len(subscriptions) > 0:
@@ -47,93 +133,141 @@ class Portfolio:
 
             if subscription["type"] == "instrument":
                 await self.tr.unsubscribe(subscription_id)
-                pos = subscriptions.pop(subscription_id)
+                pos = subscriptions.pop(subscription_id, None)
                 pos["name"] = response["shortName"]
                 pos["exchangeIds"] = response["exchangeIds"]
             else:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
-        # Populate netValue for each ISIN
+        # Get tickers and populate netValue for each ISIN
         subscriptions = {}
-        for pos in sorted(positions, key=lambda x: x["netSize"], reverse=True):
+        for pos in self.portfolio:
             isin = pos["instrumentId"]
             if len(pos["exchangeIds"]) > 0:
                 subscription_id = await self.tr.ticker(isin, exchange=pos["exchangeIds"][0])
                 subscriptions[subscription_id] = pos
-            else:
-                pos["netValue"] = float(pos["averageBuyIn"]) * float(pos["netSize"])
 
         while len(subscriptions) > 0:
             subscription_id, subscription, response = await self.tr.recv()
 
             if subscription["type"] == "ticker":
                 await self.tr.unsubscribe(subscription_id)
-                pos = subscriptions.pop(subscription_id)
-                pos["netValue"] = float(response["last"]["price"]) * float(pos["netSize"])
-
-                # We need to calculate the netValue for bonds differently
-                # We need to identify if it is a bond name - bonds have "year like 2025" in their name:
+                pos = subscriptions.pop(subscription_id, None)
+                pos["price"] = response["last"]["price"]
+                # watchlist positions don't have size/value
+                if "netSize" not in pos:
+                    pos["netSize"] = "0"
+                    pos["averageBuyIn"] = response["last"]["price"]
+                pos["netValue"] = (Decimal(response["last"]["price"]) * Decimal(pos["netSize"])).quantize(
+                    Decimal("0.01"), rounding=ROUND_HALF_UP
+                )
+                # Bond handling
+                # Identify bonds by parsing the name - bond names are like "... month year"
+                # Bond prices are per €100 face value
                 if bond_pattern.search(pos["name"]):
-                    # Bond calculation - price is per $100 face value
                     pos["netValue"] = pos["netValue"] / 100
-
             else:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
-    def portfolio_to_csv(self, output_path):
-        positions = self.portfolio["positions"]
+        # sanitize - saw this happen e.g. during capital measures when some instrument is not actively listed
+        for pos in self.portfolio:
+            if "price" not in pos:
+                print(f"Missing price for {pos['name']} ({pos['instrumentId']}), setting to 0.")
+                pos["price"] = 0.0
+                pos["netValue"] = Decimal("0.0")
+
+    def _get_sort_func(self):
+        if self.sort_by_column:
+            match self.sort_by_column.lower():
+                case "name":
+                    if self.lang == "de":
+                        locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                    return lambda x: locale.strxfrm(x["name"].lower())
+                case "isin":
+                    if self.lang == "de":
+                        locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                    return lambda x: locale.strxfrm(x["instrumentId"].lower())
+                case "quantity":
+                    return lambda x: x["netSize"]
+                case "price":
+                    return lambda x: x["price"]
+                case "avgCost":
+                    return lambda x: x["averageBuyIn"]
+                case "netValue":
+                    return lambda x: x["netValue"]
+                case _ as m:
+                    print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
+                    return lambda x: x["netValue"]
+        else:
+            return lambda x: x["netValue"]
+
+    def portfolio_to_csv(self):
+        if self.output is None:
+            return
+
         csv_lines = []
-        for pos in sorted(positions, key=lambda x: x["netSize"], reverse=True):
+        for pos in sorted(self.portfolio, key=self._get_sort_func(), reverse=self.sort_descending):
             csv_lines.append(
-                f"{pos['name']};{pos['instrumentId']};{pos['netSize']};{pos['averageBuyIn']};{float(pos['netValue']):.2f}"
+                f"{pos['name']};"
+                f"{pos['instrumentId']};"
+                f"{self._decimal_format(pos['netSize'], precision=6)};"
+                f"{self._decimal_format(pos['price'], precision=4)};"
+                f"{self._decimal_format(pos['averageBuyIn'], precision=4)};"
+                f"{self._decimal_format(pos['netValue'])}"
             )
 
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write("Name;ISIN;quantity;avgCost;netValue\n")
+        with open(self.output, "w", encoding="utf-8") as f:
+            f.write("Name;ISIN;quantity;price;avgCost;netValue\n")
             f.write("\n".join(csv_lines) + ("\n" if csv_lines else ""))
 
-        print(f"Wrote {len(csv_lines) + 1} lines to {output_path}")
+        print(f"Wrote {len(csv_lines) + 1} lines to {self.output}")
 
     def overview(self):
-        print(
-            "Name                      ISIN            avgCost *   quantity =    buyCost ->   netValue       diff   %-diff"
-        )
-        totalBuyCost = 0.0
-        totalNetValue = 0.0
-        positions = self.portfolio["positions"]
-        for pos in sorted(positions, key=lambda x: x["netSize"], reverse=True):
-            buyCost = float(pos["averageBuyIn"]) * float(pos["netSize"])
-            diff = float(pos["netValue"]) - buyCost
-            if buyCost == 0:
-                diffP = 0.0
-            else:
-                diffP = ((pos["netValue"] / buyCost) - 1) * 100
-            totalBuyCost += buyCost
-            totalNetValue += float(pos["netValue"])
+        totalBuyCost = Decimal("0")
+        totalNetValue = Decimal("0")
 
+        if not self.output:
             print(
-                f"{pos['name']:<25.25} {pos['instrumentId']} {float(pos['averageBuyIn']):>10.2f} * {float(pos['netSize']):>10.3f}"
-                + f" = {float(buyCost):>10.2f} -> {float(pos['netValue']):>10.2f} {diff:>10.2f} {diffP:>7.1f}%"
+                "Name                      ISIN            avgCost *   quantity =    buyCost ->   netValue      price       diff   %-diff"
             )
 
-        print(
-            "Name                      ISIN            avgCost *   quantity =    buyCost ->   netValue       diff   %-diff"
-        )
-        print()
+        for pos in sorted(self.portfolio, key=self._get_sort_func(), reverse=self.sort_descending):
+            buyCost = (Decimal(pos["averageBuyIn"]) * Decimal(pos["netSize"])).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
+            diff = pos["netValue"] - buyCost
+            diffP = 0.0 if buyCost == 0 else ((pos["netValue"] / buyCost) - 1) * 100
+            totalBuyCost = totalBuyCost + buyCost
+            totalNetValue = totalNetValue + pos["netValue"]
+
+            if not self.output:
+                print(
+                    f"{pos['name']:<25.25} "
+                    f"{pos['instrumentId']} "
+                    f"{Decimal(pos['averageBuyIn']):>10.2f} * "
+                    f"{Decimal(pos['netSize']):>10.6f} = "
+                    f"{buyCost:>10.2f} -> "
+                    f"{pos['netValue']:>10.2f} "
+                    f"{Decimal(pos['price']):>10.2f} "
+                    f"{diff:>10.2f} "
+                    f"{diffP:>7.1f}%"
+                )
+
+        if not self.output:
+            print(
+                "Name                      ISIN            avgCost *   quantity =    buyCost ->   netValue      price       diff   %-diff"
+            )
+            print()
 
         diff = totalNetValue - totalBuyCost
-        if totalBuyCost == 0:
-            diffP = 0.0
-        else:
-            diffP = ((totalNetValue / totalBuyCost) - 1) * 100
+        diffP = 0.0 if totalBuyCost == 0 else ((totalNetValue / totalBuyCost) - 1) * 100
+        cash = Decimal(self.cash[0]["amount"])
         print(f"Depot {totalBuyCost:>43.2f} -> {totalNetValue:>10.2f} {diff:>10.2f} {diffP:>7.1f}%")
-
-        cash = float(self.cash[0]["amount"])
-        currency = self.cash[0]["currencyId"]
-        print(f"Cash {currency} {cash:>40.2f} -> {cash:>10.2f}")
+        print(f"Cash {self.cash[0]['currencyId']} {cash:>40.2f}")
         print(f"Total {cash + totalBuyCost:>43.2f} -> {cash + totalNetValue:>10.2f}")
 
     def get(self):
         asyncio.get_event_loop().run_until_complete(self.portfolio_loop())
 
         self.overview()
+        self.portfolio_to_csv()


### PR DESCRIPTION
This change adds some features to portfolio export.

It is now possible to optionally include watchlist positions. If included, they will have a quantity of 0 obviously.
A price column was added to the output.
It is now possible to sort the output by a certain column. Default sorting is by market value, descending (as you see it in the Trade Republic app).
When you epxort the data to a csv file, only the overview is shown in console output.
