### PR TITLE
Parse events without eventType field (not complete)

### DIFF
--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -230,7 +230,7 @@ class Timeline:
             event["has_docs"] = True
             subfolder = None
 
-            if event["eventType"] == "timeline_legacy_migrated_events":
+            if event.get("eventType", "") == "timeline_legacy_migrated_events":
                 subtitle = event.get("subtitle", "")
                 if event.get("title", "") == "Zinsen":
                     subfolder = "Zinsen"
@@ -249,10 +249,10 @@ class Timeline:
                         f"no mapping for timeline_legacy_migrated_events: title={event.get('title', '')} subtitle={event.get('subtitle', '')}"
                     )
             else:
-                subfolder = event_subfolder_mapping.get(event["eventType"])
+                subfolder = event_subfolder_mapping.get(event.get("eventType", ""))
 
             if subfolder is None:
-                self.log.warning(f"no mapping for {event['eventType']}")
+                self.log.warning(f"no mapping for {event.get('eventType', '')}")
 
             for doc in section["data"]:
                 timestamp_str = event["timestamp"]

--- a/tests/dividende_no_eventType.json
+++ b/tests/dividende_no_eventType.json
@@ -1,0 +1,169 @@
+{
+    "id": "de17e7cb-49cd-322f-8345-1b265dc9730d",
+    "timestamp": "2025-11-05T18:31:19.339+0000",
+    "title": "Lowe's",
+    "icon": "logos/US5486611073/v2",
+    "avatar": {
+        "asset": "logos/US5486611073/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Bardividende",
+    "amount": {
+        "currency": "EUR",
+        "value": 0.92,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "de17e7cb-49cd-322f-8345-1b265dc9730d"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "de17e7cb-49cd-322f-8345-1b265dc9730d",
+        "sections": [
+            {
+                "title": "Du hast 0,92\u00a0\u20ac erhalten",
+                "data": {
+                    "icon": "logos/US5486611073/v2",
+                    "timestamp": "2025-11-05T18:31:19.339Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Status",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Event",
+                        "detail": {
+                            "text": "Bardividende",
+                            "displayValue": {
+                                "text": "Bardividende"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Wertpapier",
+                        "detail": {
+                            "text": "Lowe's",
+                            "displayValue": {
+                                "text": "Lowe's"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Gesch\u00e4ft",
+                "data": [
+                    {
+                        "title": "Aktien",
+                        "detail": {
+                            "text": "1.189904",
+                            "displayValue": {
+                                "text": "1.189904"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Dividende pro Aktie",
+                        "detail": {
+                            "text": "1,20\u00a0$",
+                            "displayValue": {
+                                "text": "1,20\u00a0$"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Steuer",
+                        "detail": {
+                            "text": "-0,32\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "-0,32\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Gesamt",
+                        "detail": {
+                            "text": "0,92\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "0,92\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Dokumente",
+                        "detail": "05.11.2025",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "36b29c55-5bef-44c3-b50c-7541403a9414",
+                        "postboxType": "CA_INCOME_INVOICE"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "common_empty_string",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "timelineEventId": "de17e7cb-49cd-322f-8345-1b265dc9730d",
+                                        "chat_flow_key": "NHC_0029_wealth_general_question_dividends"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "highlighted"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/kartenzahlung_no_eventType.json
+++ b/tests/kartenzahlung_no_eventType.json
@@ -1,0 +1,117 @@
+{
+    "id": "809a35a2-99d6-5fcd-ba87-fd618f90710a",
+    "timestamp": "2025-11-05T11:00:07.718+0000",
+    "title": "Baecker",
+    "icon": "logos/merchant-fallback-restaurants/v2",
+    "avatar": {
+        "asset": "logos/merchant-fallback-restaurants/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": null,
+    "amount": {
+        "currency": "EUR",
+        "value": -2.0,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "809a35a2-99d6-5fcd-ba87-fd618f90710a"
+    },
+    "cashAccountNumber": null,
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "809a35a2-99d6-5fcd-ba87-fd618f90710a",
+        "sections": [
+            {
+                "title": "Du hast 2,00\u00a0\u20ac ausgegeben",
+                "data": {
+                    "icon": "logos/merchant-fallback-restaurants/v2",
+                    "timestamp": "2025-11-05T11:00:07.718Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Kartenzahlung",
+                        "detail": {
+                            "text": "Ausstehend",
+                            "action": {
+                                "payload": {
+                                    "id": "809a35a2-99d6-5fcd-ba87-fd618f90710a",
+                                    "sections": [
+                                        {
+                                            "title": "Ausstehende Transaktionen",
+                                            "type": "title"
+                                        },
+                                        {
+                                            "text": "Diese Transaktion kann von uns nicht storniert werden und wird automatisch auf 13 November r\u00fcckg\u00e4ngig gemacht, wenn sie vom H\u00e4ndler nicht in Anspruch genommen wird.",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "data": {
+                                                "title": "Weitere Informationen",
+                                                "action": {
+                                                    "payload": {
+                                                        "link": "traderepublic://help-center/269df522-bbbc-43bd-914a-ac4def329069"
+                                                    },
+                                                    "type": "deeplink"
+                                                }
+                                            },
+                                            "type": "actionButtons"
+                                        }
+                                    ]
+                                },
+                                "type": "infoPage"
+                            },
+                            "displayValue": {
+                                "text": "Ausstehend"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Zahlung",
+                        "detail": {
+                            "text": "\u00b7\u00b75891",
+                            "icon": "logos/bank_traderepublic/v2",
+                            "type": "iconWithText"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "H\u00e4ndler",
+                        "detail": {
+                            "text": "Baecker",
+                            "displayValue": {
+                                "text": "Baecker"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Gesamt",
+                        "detail": {
+                            "text": "2,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "2,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/limit-sell-order_no_eventType.json
+++ b/tests/limit-sell-order_no_eventType.json
@@ -1,0 +1,268 @@
+{
+    "id": "89c3a1b3-7af2-4256-ba1b-6a28338ebadf",
+    "timestamp": "2025-11-05T12:03:19.648+0000",
+    "title": "Teva Pharmaceutical Industries (ADR)",
+    "icon": "logos/US8816242098/v2",
+    "avatar": {
+        "asset": "logos/US8816242098/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Limit-Sell-Order",
+    "amount": {
+        "currency": "EUR",
+        "value": 139.74,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "89c3a1b3-7af2-4256-ba1b-6a28338ebadf"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "89c3a1b3-7af2-4256-ba1b-6a28338ebadf",
+        "sections": [
+            {
+                "title": "Du hast 139,74\u00a0\u20ac erhalten",
+                "data": {
+                    "icon": "logos/US8816242098/v2",
+                    "timestamp": "2025-11-05T12:03:19.648Z",
+                    "status": "executed"
+                },
+                "action": {
+                    "payload": "US8816242098",
+                    "type": "instrumentDetail"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Portfolio",
+                        "detail": {
+                            "text": "Brokerage",
+                            "displayValue": {
+                                "text": "Brokerage"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Limit Order",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Asset",
+                        "detail": {
+                            "text": "Teva Pharmaceutical Industries (ADR)",
+                            "displayValue": {
+                                "text": "Teva Pharmaceutical Industries (ADR)"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Transaktion",
+                        "detail": {
+                            "text": "8 \u00d7  18,55\u00a0\u20ac",
+                            "action": {
+                                "payload": {
+                                    "id": "00000000-0000-0000-0000-000000000000",
+                                    "sections": [
+                                        {
+                                            "title": "Transaktion",
+                                            "type": "title"
+                                        },
+                                        {
+                                            "data": [
+                                                {
+                                                    "title": "Aktien",
+                                                    "detail": {
+                                                        "text": "8",
+                                                        "displayValue": {
+                                                            "text": "8"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Aktienkurs",
+                                                    "detail": {
+                                                        "text": "18,55\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "18,55\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Summe",
+                                                    "detail": {
+                                                        "text": "148,40\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "148,40\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                }
+                                            ],
+                                            "type": "table"
+                                        }
+                                    ]
+                                },
+                                "type": "infoPage"
+                            },
+                            "displayValue": {
+                                "text": "18,55\u00a0\u20ac",
+                                "prefix": "8 \u00d7 "
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Steuer",
+                        "detail": {
+                            "text": "7,66\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "7,66\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Geb\u00fchr",
+                        "detail": {
+                            "text": "1,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "1,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Summe",
+                        "detail": {
+                            "text": "139,74\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "139,74\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Performance",
+                "data": [
+                    {
+                        "title": "Rendite",
+                        "detail": {
+                            "text": "22,96 %",
+                            "trend": "positive",
+                            "displayValue": {
+                                "text": "22,96 %"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Gewinn",
+                        "detail": {
+                            "text": "27,52\u00a0\u20ac",
+                            "trend": "positive",
+                            "displayValue": {
+                                "text": "27,52\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "horizontalTable"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Kosteninformation",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "eb32bdce-1b2a-4a56-882a-24cb814ee867",
+                        "postboxType": "EQUITIES_SELL_EX_ANTE"
+                    },
+                    {
+                        "title": "Auftragsbest\u00e4tigung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "96eccb8a-cca0-47aa-a2aa-ee5427d8eb26",
+                        "postboxType": "ORDER_CONFIRMATION"
+                    },
+                    {
+                        "title": "Abrechnung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "88b2b6cc-aa38-46e4-bb93-6b54b1dfee32",
+                        "postboxType": "SECURITIES_SETTLEMENT"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "chat_flow_key": "NHC_0029_wealth_buying_selling_past_trade_execution",
+                                        "timelineEventId": "89c3a1b3-7af2-4256-ba1b-6a28338ebadf",
+                                        "instrumentType": "stock",
+                                        "instrumentId": "US8816242098",
+                                        "primId": "N1549193313"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/saveback_no_eventType.json
+++ b/tests/saveback_no_eventType.json
@@ -1,0 +1,147 @@
+{
+    "id": "b5999007-483d-4013-b582-347471a42a6a",
+    "timestamp": "2025-11-03T15:30:22.202+0000",
+    "title": "Lockheed Martin",
+    "icon": "logos/US5398301094/v2",
+    "avatar": {
+        "asset": "logos/US5398301094/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Saveback",
+    "amount": {
+        "currency": "EUR",
+        "value": -15.0,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "b5999007-483d-4013-b582-347471a42a6a"
+    },
+    "cashAccountNumber": null,
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "b5999007-483d-4013-b582-347471a42a6a",
+        "sections": [
+            {
+                "title": "Du hast 15,00\u00a0\u20ac erhalten",
+                "data": {
+                    "icon": "logos/US5398301094/v2",
+                    "timestamp": "2025-11-03T15:30:22.202665Z",
+                    "status": "executed"
+                },
+                "action": {
+                    "payload": "US5398301094",
+                    "type": "instrumentDetail"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Saveback",
+                        "detail": {
+                            "text": "Abgeschlossen",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Asset",
+                        "detail": {
+                            "text": "Lockheed Martin",
+                            "displayValue": {
+                                "text": "Lockheed Martin"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Transaktion",
+                        "detail": {
+                            "text": "0.035252 x  425,50\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "425,50\u00a0\u20ac",
+                                "prefix": "0.035252 x "
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Geb\u00fchr",
+                        "detail": {
+                            "text": "Kostenlos",
+                            "displayValue": {
+                                "text": "Kostenlos"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Gesamt",
+                        "detail": {
+                            "text": "15,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "15,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "highlighted"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Wertpapierabrechnung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "0117fe00-93e5-47c2-9f7f-85f72d51da48",
+                        "postboxType": "SECURITIES_SETTLEMENT_SAVINGS_PLAN"
+                    },
+                    {
+                        "title": "Aktivierung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "6387ff2c-656c-4f9a-a238-4a151dff6212",
+                        "postboxType": "BENEFIT_ACTIVATED"
+                    },
+                    {
+                        "title": "Kosteninformation",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "29cca886-9baa-4153-947f-8dba06e618c9",
+                        "postboxType": "COSTS_INFO_SAVINGS_PLAN"
+                    },
+                    {
+                        "title": "Auftragsbest\u00e4tigung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "3da1d209-7d52-4017-8397-1b9817f68432",
+                        "postboxType": "SAVINGS_PLAN_CREATED"
+                    }
+                ],
+                "type": "documents"
+            }
+        ]
+    }
+}

--- a/tests/savingsplan_no_eventType.json
+++ b/tests/savingsplan_no_eventType.json
@@ -1,0 +1,231 @@
+{
+    "id": "78862117-79a9-4330-b594-ec62c3685a16",
+    "timestamp": "2025-11-03T15:58:11.121+0000",
+    "title": "TSMC (ADR)",
+    "icon": "logos/US8740391003/v2",
+    "avatar": {
+        "asset": "logos/US8740391003/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Sparplan ausgef\u00fchrt",
+    "amount": {
+        "currency": "EUR",
+        "value": -10.0,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "78862117-79a9-4330-b594-ec62c3685a16"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "78862117-79a9-4330-b594-ec62c3685a16",
+        "sections": [
+            {
+                "title": "Du hast 10,00\u00a0\u20ac gespart",
+                "data": {
+                    "icon": "logos/US8740391003/v2",
+                    "timestamp": "2025-11-03T15:58:11.121982Z",
+                    "status": "executed"
+                },
+                "action": {
+                    "payload": "US8740391003",
+                    "type": "instrumentDetail"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Sparplan",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Zahlung",
+                        "detail": {
+                            "text": "Cash",
+                            "icon": "logos/bank_traderepublic/v2",
+                            "type": "iconWithText"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Asset",
+                        "detail": {
+                            "text": "TSMC (ADR)",
+                            "displayValue": {
+                                "text": "TSMC (ADR)"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Transaktion",
+                        "detail": {
+                            "text": "0,037523 \u00d7  266,50\u00a0\u20ac",
+                            "action": {
+                                "payload": {
+                                    "id": "00000000-0000-0000-0000-000000000000",
+                                    "sections": [
+                                        {
+                                            "title": "Transaktion",
+                                            "type": "title"
+                                        },
+                                        {
+                                            "data": [
+                                                {
+                                                    "title": "Aktien",
+                                                    "detail": {
+                                                        "text": "0,037523",
+                                                        "displayValue": {
+                                                            "text": "0,037523"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Aktienkurs",
+                                                    "detail": {
+                                                        "text": "266,50\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "266,50\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Summe",
+                                                    "detail": {
+                                                        "text": "10,00\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "10,00\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                }
+                                            ],
+                                            "type": "table"
+                                        }
+                                    ]
+                                },
+                                "type": "infoPage"
+                            },
+                            "displayValue": {
+                                "text": "266,50\u00a0\u20ac",
+                                "prefix": "0,037523 \u00d7 "
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Geb\u00fchr",
+                        "detail": {
+                            "text": "Kostenlos",
+                            "displayValue": {
+                                "text": "Kostenlos"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Summe",
+                        "detail": {
+                            "text": "10,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "10,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Sparplan",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "title": "TSMC (ADR)",
+                            "timestamp": "2025-11-03T15:58:11.121982Z",
+                            "amount": "10,00\u00a0\u20ac",
+                            "icon": "logos/US8740391003/v2",
+                            "status": "executed",
+                            "action": {
+                                "payload": {
+                                    "savingsPlanId": "407449dc-fce1-48c3-93a6-e86919e5b385"
+                                },
+                                "type": "openSavingsPlanOverview"
+                            },
+                            "subtitle": "W\u00f6chentlich",
+                            "type": "embeddedTimelineItem"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Abrechnungsausf\u00fchrung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "548c51bd-f5c3-45f4-b794-b68bb90dc10c",
+                        "postboxType": "SECURITIES_SETTLEMENT_SAVINGS_PLAN"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "chat_flow_key": "NHC_0029_wealth_Failed_savings_plan_execution",
+                                        "timelineEventId": "78862117-79a9-4330-b594-ec62c3685a16",
+                                        "savingsPlanId": "407449dc-fce1-48c3-93a6-e86919e5b385",
+                                        "primId": "N1546849464"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/steuerkorrektur_no_eventType.json
+++ b/tests/steuerkorrektur_no_eventType.json
@@ -1,0 +1,125 @@
+{
+    "id": "0a3c14cf-0688-374e-99fc-3b690e1a7ea3",
+    "timestamp": "2025-11-04T23:31:58.000+0000",
+    "title": "Steuerkorrektur",
+    "icon": "logos/timeline_person/v2",
+    "avatar": {
+        "asset": "logos/timeline_person/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": null,
+    "amount": {
+        "currency": "EUR",
+        "value": 0.76,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "0a3c14cf-0688-374e-99fc-3b690e1a7ea3"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "0a3c14cf-0688-374e-99fc-3b690e1a7ea3",
+        "sections": [
+            {
+                "title": "Du hast 0,76\u00a0\u20ac erhalten",
+                "data": {
+                    "icon": "logos/timeline_person/v2",
+                    "timestamp": "2025-11-04T23:31:58Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Status",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Event",
+                        "detail": {
+                            "text": "Steuerkorrektur",
+                            "displayValue": {
+                                "text": "Steuerkorrektur"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Gesch\u00e4ft",
+                "data": [
+                    {
+                        "title": "Gesamt",
+                        "detail": {
+                            "text": "0,76\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "0,76\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Steuerabrechnung",
+                        "detail": "04.11.2025",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "b1cbfe63-4737-4112-a8c7-033f69d1ed49",
+                        "postboxType": "TAX_OPTIMIZATION_INVOICE"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "common_empty_string",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "timelineEventId": "0a3c14cf-0688-374e-99fc-3b690e1a7ea3",
+                                        "chat_flow_key": "NHC_0029_tax_optimization_picker"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "highlighted"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/tausch_no_eventType.json
+++ b/tests/tausch_no_eventType.json
@@ -1,0 +1,72 @@
+{
+    "id": "bbf2affb-30ab-45bd-a7d6-d3047360e905",
+    "timestamp": "2025-11-04T08:59:35.225+0000",
+    "title": "L'Oreal",
+    "icon": "logos/FR0000120321/v2",
+    "subtitle": "Tausch",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "bbf2affb-30ab-45bd-a7d6-d3047360e905"
+    },
+    "source": "timelineActivity",
+    "details": {
+        "id": "bbf2affb-30ab-45bd-a7d6-d3047360e905",
+        "sections": [
+            {
+                "title": "Du hast eine Kapitalma\u00dfnahme erhalten",
+                "data": {
+                    "icon": "logos/FR0000120321/v2",
+                    "timestamp": "2025-11-04T08:59:35.225Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "Information",
+                "text": "Das beigef\u00fcgte Dokument enth\u00e4lt wichtige Informationen zu deiner L'Oreal-Investition. Bitte \u00fcberpr\u00fcfe das Dokument.",
+                "type": "text"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Kapitalma\u00dfnahmen",
+                        "detail": "04.11.2025",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "e68a0462-3569-4eea-a33c-f5b10154986a",
+                        "postboxType": "CA_GENERIC_OPTIONS_NOTIFICATION"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "common_empty_string",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "timelineEventId": "bbf2affb-30ab-45bd-a7d6-d3047360e905",
+                                        "chat_flow_key": "NHC_0029_wealth_general_question_corporate_action"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "highlighted"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -153,3 +153,157 @@ def test_private_markets_bonus_event_from_dict():
     assert event.event_type == ConditionalEventType.PRIVATE_MARKETS_ORDER
     assert event.value == -1
     assert event.shares == 1
+
+
+def test_dividende_no_eventType():
+    # Load the sample JSON file
+    with open("tests/dividende_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.DIVIDEND
+    assert event.isin == "US5486611073"
+    assert event.title == "Lowe's"
+    assert event.shares == 1.189904
+    assert event.value == 0.92
+    assert event.taxes == -0.32
+
+
+def test_kartenzahlung_no_eventType():
+    # Load the sample JSON file
+    with open("tests/kartenzahlung_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.REMOVAL
+    assert event.title == "Baecker"
+    assert event.value == -2
+
+
+def test_ueberweisung_no_eventType():
+    # Load the sample JSON file
+    with open("tests/ueberweisung_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.DEPOSIT
+    assert event.title == "Jens Mueller"
+    assert event.value == 14.41
+
+
+def test_steuerkorrektur_no_eventType():
+    # Load the sample JSON file
+    with open("tests/steuerkorrektur_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.TAX_REFUND
+    assert event.title == "Steuerkorrektur"
+    assert event.value == 0.76
+
+
+def test_zinsen_no_eventType():
+    # Load the sample JSON file
+    with open("tests/zinsen_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == PPEventType.INTEREST
+    assert event.title == "Zinsen"
+    assert event.value == 3.6
+    assert event.taxes == 0.2
+
+
+def test_tausch_no_eventType():
+    # Load the sample JSON file
+    with open("tests/tausch_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type is None
+
+
+def test_limit_sell_order_no_eventType():
+    # Load the sample JSON file
+    with open("tests/limit-sell-order_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == ConditionalEventType.TRADE_INVOICE
+    assert event.isin == "US8816242098"
+    assert event.title == "Teva Pharmaceutical Industries (ADR)"
+    assert event.shares == 8
+    assert event.value == 139.74
+    assert event.taxes == 7.66
+
+
+def test_verkaufsorder_no_eventType():
+    # Load the sample JSON file
+    with open("tests/verkaufsorder_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == ConditionalEventType.TRADE_INVOICE
+    assert event.isin == "US4370761029"
+    assert event.title == "Home Depot"
+    assert event.shares == 0.305182
+    assert event.value == 100
+    assert event.taxes is None
+
+
+def test_savingsplan_no_eventType():
+    # Load the sample JSON file
+    with open("tests/savingsplan_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == ConditionalEventType.TRADE_INVOICE
+    assert event.isin == "US8740391003"
+    assert event.title == "TSMC (ADR)"
+    assert event.shares == 0.037523
+    assert event.value == -10
+    assert event.taxes is None
+
+
+def test_saveback_no_eventType():
+    # Load the sample JSON file
+    with open("tests/saveback_no_eventType.json", "r", encoding="utf-8") as file:
+        sample_data = json.load(file)
+
+    # Parse the JSON data using the from_dict function
+    event = Event.from_dict(sample_data)
+
+    # Assert the expected values
+    assert event.event_type == ConditionalEventType.SAVEBACK
+    assert event.isin == "US5398301094"
+    assert event.title == "Lockheed Martin"
+    assert event.shares == 0.035252
+    assert event.value == -15
+    assert event.taxes is None

--- a/tests/ueberweisung_no_eventType.json
+++ b/tests/ueberweisung_no_eventType.json
@@ -1,0 +1,187 @@
+{
+    "id": "60518353-20ba-457a-9114-fdc887ae1fba",
+    "timestamp": "2025-11-05T09:21:28.041+0000",
+    "title": "Jens Mueller",
+    "icon": "logos/contacts-C-Grey/v2",
+    "avatar": {
+        "asset": "logos/contacts-C-Grey/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Fertig",
+    "amount": {
+        "currency": "EUR",
+        "value": 14.41,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "60518353-20ba-457a-9114-fdc887ae1fba"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "60518353-20ba-457a-9114-fdc887ae1fba",
+        "sections": [
+            {
+                "title": "Du hast 14,41\u00a0\u20ac von Jens Mueller erhalten",
+                "data": {
+                    "icon": "logos/contacts-C-Grey/v2",
+                    "timestamp": "2025-11-05T09:21:28.037785Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "\u00dcberweisung",
+                        "detail": {
+                            "text": "Abgeschlossen",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Absender",
+                        "detail": {
+                            "text": "Jens Mueller",
+                            "displayValue": {
+                                "text": "Jens Mueller"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "IBAN",
+                        "detail": {
+                            "text": "..1200",
+                            "action": {
+                                "payload": {
+                                    "id": "60518353-20ba-457a-9114-fdc887ae1fba",
+                                    "sections": [
+                                        {
+                                            "title": "IBAN",
+                                            "data": [
+                                                {
+                                                    "title": "DE12 3456 7890 1234 567 89",
+                                                    "detail": {
+                                                        "icon": "logos/bank_comdirect/v2",
+                                                        "style": "highlighted",
+                                                        "type": "listItemAvatarDefault"
+                                                    },
+                                                    "style": "plain"
+                                                }
+                                            ],
+                                            "type": "table"
+                                        }
+                                    ]
+                                },
+                                "type": "infoPage"
+                            },
+                            "displayValue": {
+                                "text": "..1200"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Gesamt",
+                        "detail": {
+                            "text": "+14,41\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "+14,41\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "data": {
+                    "text": "Text"
+                },
+                "type": "note"
+            },
+            {
+                "title": "Absender",
+                "data": [
+                    {
+                        "title": "Absender",
+                        "detail": {
+                            "text": "Jens Mueller",
+                            "displayValue": {
+                                "text": "Jens Mueller"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "IBAN",
+                        "detail": {
+                            "text": "DE12 3456 7890 1234 567 89",
+                            "displayValue": {
+                                "text": "DE12 3456 7890 1234 567 89"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokument",
+                "data": [
+                    {
+                        "title": "Transaktionsbest\u00e4tigung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "f5bef8df-3452-4d9b-a7e2-7896ad01e6c8",
+                        "postboxType": "INCOMING_TRANSFER"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "timelineEventId": "60518353-20ba-457a-9114-fdc887ae1fba",
+                                        "transferId": "3068ed91-be29-44c7-9db3-8fc64d4fe89e",
+                                        "chat_flow_key": "NHC_0024_deposit_report_an_issue"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/verkaufsorder_no_eventType.json
+++ b/tests/verkaufsorder_no_eventType.json
@@ -1,0 +1,259 @@
+{
+    "id": "c082a8d2-8816-4d33-829b-6cb78584df34",
+    "timestamp": "2025-11-04T16:27:25.185+0000",
+    "title": "Home Depot",
+    "icon": "logos/US4370761029/v2",
+    "avatar": {
+        "asset": "logos/US4370761029/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "Verkaufsorder",
+    "amount": {
+        "currency": "EUR",
+        "value": 100.0,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "c082a8d2-8816-4d33-829b-6cb78584df34"
+    },
+    "cashAccountNumber": "",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "c082a8d2-8816-4d33-829b-6cb78584df34",
+        "sections": [
+            {
+                "title": "Du hast 100,00\u00a0\u20ac erhalten",
+                "data": {
+                    "icon": "logos/US4370761029/v2",
+                    "timestamp": "2025-11-04T16:27:25.185Z",
+                    "status": "executed"
+                },
+                "action": {
+                    "payload": "US4370761029",
+                    "type": "instrumentDetail"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Portfolio",
+                        "detail": {
+                            "text": "Brokerage",
+                            "displayValue": {
+                                "text": "Brokerage"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Verkaufen",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Asset",
+                        "detail": {
+                            "text": "Home Depot",
+                            "displayValue": {
+                                "text": "Home Depot"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Transaktion",
+                        "detail": {
+                            "text": "0,305182 \u00d7  330,95\u00a0\u20ac",
+                            "action": {
+                                "payload": {
+                                    "id": "00000000-0000-0000-0000-000000000000",
+                                    "sections": [
+                                        {
+                                            "title": "Transaktion",
+                                            "type": "title"
+                                        },
+                                        {
+                                            "data": [
+                                                {
+                                                    "title": "Aktien",
+                                                    "detail": {
+                                                        "text": "0,305182",
+                                                        "displayValue": {
+                                                            "text": "0,305182"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Aktienkurs",
+                                                    "detail": {
+                                                        "text": "330,95\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "330,95\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                },
+                                                {
+                                                    "title": "Summe",
+                                                    "detail": {
+                                                        "text": "101,00\u00a0\u20ac",
+                                                        "displayValue": {
+                                                            "text": "101,00\u00a0\u20ac"
+                                                        },
+                                                        "type": "text"
+                                                    },
+                                                    "style": "plain"
+                                                }
+                                            ],
+                                            "type": "table"
+                                        }
+                                    ]
+                                },
+                                "type": "infoPage"
+                            },
+                            "displayValue": {
+                                "text": "330,95\u00a0\u20ac",
+                                "prefix": "0,305182 \u00d7 "
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Steuer",
+                        "detail": {
+                            "text": "0,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "0,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Geb\u00fchr",
+                        "detail": {
+                            "text": "1,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "1,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Summe",
+                        "detail": {
+                            "text": "100,00\u00a0\u20ac",
+                            "displayValue": {
+                                "text": "100,00\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Performance",
+                "data": [
+                    {
+                        "title": "Rendite",
+                        "detail": {
+                            "text": "19,22 %",
+                            "trend": "negative",
+                            "displayValue": {
+                                "text": "19,22 %"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    },
+                    {
+                        "title": "Verlust",
+                        "detail": {
+                            "text": "-16,12\u00a0\u20ac",
+                            "trend": "negative",
+                            "displayValue": {
+                                "text": "-16,12\u00a0\u20ac"
+                            },
+                            "type": "text"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "horizontalTable"
+            },
+            {
+                "title": "Dokumente",
+                "data": [
+                    {
+                        "title": "Abrechnung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "b5d0cd84-ed10-4e52-9582-61b313e45593",
+                        "postboxType": "SECURITIES_SETTLEMENT"
+                    },
+                    {
+                        "title": "Kosteninformation",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "df64bd22-637b-4d24-b201-eafa7bc6a2d1",
+                        "postboxType": "EQUITIES_SELL_EX_ANTE"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "detail": {
+                            "icon": "",
+                            "action": {
+                                "payload": {
+                                    "contextCategory": "NHC",
+                                    "contextParams": {
+                                        "chat_flow_key": "NHC_0029_wealth_buying_selling_past_trade_execution",
+                                        "timelineEventId": "c082a8d2-8816-4d33-829b-6cb78584df34",
+                                        "instrumentType": "stock",
+                                        "instrumentId": "US4370761029",
+                                        "groupId": "c082a8d2-8816-4d33-829b-6cb78584df34"
+                                    }
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "style": "highlighted",
+                            "type": "listItemAvatarDefault"
+                        },
+                        "style": "plain"
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}

--- a/tests/zinsen_no_eventType.json
+++ b/tests/zinsen_no_eventType.json
@@ -1,0 +1,190 @@
+{
+    "id": "019a3d4a-7d3a-7733-9027-c0c996d414c3",
+    "timestamp": "2025-11-01T07:47:47.979+0000",
+    "title": "Zinsen",
+    "icon": "logos/timeline_interest_new/v2",
+    "avatar": {
+        "asset": "logos/timeline_interest_new/v2",
+        "badge": null
+    },
+    "badge": null,
+    "subtitle": "2\u00a0% p.a.",
+    "amount": {
+        "currency": "EUR",
+        "value": 3.6,
+        "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+        "type": "timelineDetail",
+        "payload": "019a3d4a-7d3a-7733-9027-c0c996d414c3"
+    },
+    "cashAccountNumber": null,
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineTransaction",
+    "details": {
+        "id": "019a3d4a-7d3a-7733-9027-c0c996d414c3",
+        "sections": [
+            {
+                "title": "Du hast \u20ac3.60 erhalten",
+                "data": {
+                    "icon": "logos/timeline_interest_new/v2",
+                    "timestamp": "2025-11-01T08:47:53.912935+01:00",
+                    "status": "executed"
+                },
+                "type": "header"
+            },
+            {
+                "title": "\u00dcbersicht",
+                "data": [
+                    {
+                        "title": "Status",
+                        "style": "plain",
+                        "detail": {
+                            "text": "Ausgef\u00fchrt",
+                            "functionalStyle": "EXECUTED",
+                            "type": "status"
+                        }
+                    },
+                    {
+                        "title": "Durchschnittssaldo",
+                        "style": "plain",
+                        "detail": {
+                            "text": "\u20ac7,886.25",
+                            "type": "text"
+                        }
+                    },
+                    {
+                        "title": "J\u00e4hrliche Rate",
+                        "style": "plain",
+                        "detail": {
+                            "text": "2.00 %",
+                            "type": "text"
+                        }
+                    },
+                    {
+                        "title": "Asset",
+                        "style": "plain",
+                        "detail": {
+                            "text": "Cash",
+                            "type": "text"
+                        }
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Status",
+                "steps": [
+                    {
+                        "leading": {
+                            "avatar": {
+                                "status": "completed",
+                                "type": "bullet"
+                            },
+                            "connection": {
+                                "order": "first"
+                            }
+                        },
+                        "content": {
+                            "title": "Zinsberechnung",
+                            "subtitle": null,
+                            "timestamp": "2025-11-01T08:47:53.912935+01:00",
+                            "cta": null
+                        }
+                    },
+                    {
+                        "leading": {
+                            "avatar": {
+                                "status": "completed",
+                                "type": "bullet"
+                            },
+                            "connection": {
+                                "order": "last"
+                            }
+                        },
+                        "content": {
+                            "title": "Zinszahlung",
+                            "subtitle": null,
+                            "timestamp": "2025-11-01T08:47:53.912935+01:00",
+                            "cta": null
+                        }
+                    }
+                ],
+                "type": "steps"
+            },
+            {
+                "title": "Transaktion",
+                "data": [
+                    {
+                        "title": "Angesammelt",
+                        "style": "plain",
+                        "detail": {
+                            "text": "\u20ac6.40",
+                            "type": "text"
+                        }
+                    },
+                    {
+                        "title": "Steuern",
+                        "style": "plain",
+                        "detail": {
+                            "text": "\u20ac0.20",
+                            "type": "text"
+                        }
+                    },
+                    {
+                        "title": "Gesamt",
+                        "style": "plain",
+                        "detail": {
+                            "text": "\u20ac3.60",
+                            "type": "text"
+                        }
+                    }
+                ],
+                "type": "table"
+            },
+            {
+                "title": "Dokument",
+                "data": [
+                    {
+                        "title": "Abrechnung",
+                        "action": {
+                            "payload": "",
+                            "type": "browserModal"
+                        },
+                        "id": "019a3e63-1bb6-7207-b465-e16efe2a2ec2",
+                        "postboxType": "INTEREST_PAYOUT_INVOICE"
+                    }
+                ],
+                "type": "documents"
+            },
+            {
+                "title": "",
+                "data": [
+                    {
+                        "title": "",
+                        "style": "plain",
+                        "detail": {
+                            "icon": "",
+                            "style": "highlighted",
+                            "action": {
+                                "payload": {
+                                    "contextParams": {
+                                        "timelineEventId": "019a3d4a-7d3a-7733-9027-c0c996d414c3",
+                                        "chat_flow_key": "NHC_0020_interest_past_interest_payout"
+                                    },
+                                    "contextCategory": "NHC"
+                                },
+                                "type": "customerSupportChat"
+                            },
+                            "type": "listItemAvatarDefault"
+                        }
+                    }
+                ],
+                "type": "table"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This is a first change to accomodate for TR not sending the eventType field any longer.