### PR TITLE
add --nosort option do dl_docs

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -118,7 +118,7 @@ class DL:
         decimal_localization=False,
         sort_export=False,
         format_export: Literal["json", "csv"] = "csv",
-        nosort=False,
+        flat=False,
     ):
         """
         tr: api object
@@ -137,7 +137,7 @@ class DL:
         self.decimal_localization = decimal_localization
         self.sort_export = sort_export
         self.format_export: Literal["json", "csv"] = format_export
-        self.nosort = nosort
+        self.flat = flat
 
         self.tl = Timeline(
             self.tr, self.output_path, not_before, not_after, store_event_database, dump_raw_data, self.dl_callback
@@ -258,7 +258,7 @@ class DL:
         """
         doc_url = doc["action"]["payload"]
 
-        if self.nosort:
+        if self.flat:
             doc_url_base = doc_url.split("?")[0]
             filename = doc_url_base.split("/")[-1]
             filepath = self.output_path / filename

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -247,7 +247,7 @@ def get_main_parser():
         help="The output file format for the transaction export",
     )
     parser_dl_docs.add_argument(
-        "--nosort",
+        "--flat",
         default=False,
         help="Do not sort documents into folders and keep their original filenames",
         action=argparse.BooleanOptionalAction,
@@ -474,7 +474,7 @@ def main():
             decimal_localization=args.decimal_localization,
             sort_export=args.sort,
             format_export=args.export_format,
-            nosort=args.nosort,
+            flat=args.flat,
         ).do_dl()
     elif args.command == "export_transactions":
         if args.outputfile is None and args.outputdir is None:


### PR DESCRIPTION
Adds an option `--nosort` to `dl_docs`, which skips sorting and renaming the files and saves them flat under their original names.

Hint for merging: Unfortunately, the comparison suggests extensive changes, but **this is not the case**! In addition to introducing the nosort option and corresponding arguments just the following if else statement has been added to dl.py, whereby the unchanged original code has only been indented so that it is executed in the else block.
```
if self.nosort:
    doc_url_base = doc_url.split("?")[0]
    filename = doc_url_base.split("/")[-1]
    filepath = self.output_path / filename
else:
   <original file naming and sorting code>
```

This change is non-breaking.