### PR TITLE
Improved matching of details to timeline events

### DIFF
--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -200,8 +200,7 @@ class Timeline:
 
             self.requested_detail += 1
             if msg is None:
-                subscription_id = await self.tr.timeline_detail_v2(event["id"])
-                event["timeline_detail_subscription_id"] = subscription_id
+                await self.tr.timeline_detail_v2(event["id"])
             else:
                 self.received_detail += 1
                 self.events.append(event)
@@ -234,7 +233,7 @@ class Timeline:
         process timeline details response
         """
 
-        event = self.timeline_details.get(subscription_id, None)
+        event = self.timeline_details.get(subscription_id)
 
         if event is None:
             self.log.warning(f"Ignoring unrequested event response {json.dumps(response, indent=4)}")


### PR DESCRIPTION
Up to now, **details** (responses of the type `timelineDetailV2`) have been linked to **timeline events** (responses of the type `timelineTransactions `or `timelineActivityLog`) via their IDs, under the assumption that these match.  Here is the code location:

```
async def process_timelineDetail(self, response):
    """
    process timeline details response
    """

    event = self.timeline_details.get(response.get("id", "dummy"), None)
```

However, there are exceptions. For instance, in my case, only 96% of **details** share the same ID as their corresponding **timeline event**. The remaining ones have so far been treated as "unrequested event response". But in reality, there are no unrequested responses. The only issue lies in the matching process.

Some **details** even include a `timelineEventId `attribute. Unfortunately, matching via this attribute turns out to be even less reliable. For example, in my case, only 26% of the `timelineEventId` values actually match the ID of the corresponding **timeline event**.

Therefore, I’ve added a new matching approach based on the subscription ID. For me, this method achieves a 100% success rate. 

By default, the old evend ID-based matching method is still used. For the new matching method, there’s a new parameter `--details-matching` with the choices `sub_id` (new method) and `event_id` (previous method) available for both `dl_docs` and `export_transactions`.
