### PR TITLE
remove --no-flat option

### DIFF
--- a/pytr/main.py
+++ b/pytr/main.py
@@ -250,7 +250,7 @@ def get_main_parser():
         "--flat",
         default=False,
         help="Do not sort documents into folders and keep their original filenames",
-        action=argparse.BooleanOptionalAction,
+        action="store_true",
     )
 
     # export_transactions


### PR DESCRIPTION
Better read it twice. 🕵️
I don't want to remove the `--flat` option, but the `--no-flat` option. 😉

Using `action=argparse.BooleanOptionalAction` for the `--flat` option automatically creates both `--flat` and `--no-flat` options.
Since that doesn't make sense in this scenario, better use `action="store_true"`.