### PR TITLE
Use sys.exit() and import sys

### DIFF
--- a/pytr/__main__.py
+++ b/pytr/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import sys
 
 from pytr.main import main
 
@@ -9,7 +10,7 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         log = logging.getLogger(__name__)
         log.info("Exiting...")
-        exit()
+        sys.exit()
     except Exception as e:
         log = logging.getLogger(__name__)
         log.fatal(e)

--- a/pytr/account.py
+++ b/pytr/account.py
@@ -68,7 +68,7 @@ def login(phone_no=None, pin=None, web=True, store_credentials=False):
                 countdown = tr.initiate_weblogin()
             except ValueError as e:
                 log.fatal(str(e))
-                exit(1)
+                sys.exit(1)
             request_time = time.time()
             print("Enter the code you received to your mobile app as a notification.")
             print(f"Enter nothing if you want to receive the (same) code as SMS. (Countdown: {countdown})")
@@ -101,7 +101,7 @@ def login(phone_no=None, pin=None, web=True, store_credentials=False):
                 print("Reset done")
             else:
                 print("Cancelling reset")
-                exit(1)
+                sys.exit(1)
 
     log.info("Logged in")
     # log.debug(get_settings(tr))

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import shutil
 import signal
+import sys
 from datetime import datetime, timedelta
 from importlib.metadata import version
 from pathlib import Path
@@ -384,12 +385,11 @@ def exit_gracefully(signum, frame):
 
     try:
         if input("\nReally quit? (y/n)> ").lower().startswith("y"):
-            exit(1)
+            sys.exit(1)
 
     except KeyboardInterrupt:
         print("Ok ok, quitting")
-        exit(1)
-
+        sys.exit(1)
     # restore the exit gracefully handler here
     signal.signal(signal.SIGINT, exit_gracefully)
 


### PR DESCRIPTION
When exiting, `exit()` should only be used in interactive sessions. Background is that `exit()` needs the `site` module to be loaded. Therefore, use of `syst.exit()` with explicit `sys import` should be preferred.

> They are useful for the interactive interpreter shell and should not be used in programs.

https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module

Also: https://stackoverflow.com/a/19747562 