### PR TITLE
Fix type parameter in change_savings_plan requests

### DIFF
--- a/pytr/api.py
+++ b/pytr/api.py
@@ -696,7 +696,7 @@ class TradeRepublicApi:
     ):
         parameters = {
             "id": savings_plan_id,
-            "type": "createSavingsPlan",
+            "type": "changeSavingsPlan",
             "warningsShown": warnings_shown if warnings_shown else [],
             "parameters": {
                 "amount": amount,


### PR DESCRIPTION
Either this has changed, or this is just a copy/paste error.

With type `createSavingsPlan` I was getting these errors:

```
{
  "status": "failed",
  "message": "Could not create savings plan",
  "error": {
    "code": "internalError",
    "message": "Could not create savings plan",
    "details": {
      "userId": "...",
      "requestedAmount": 42.0
    }
  }
}
```