### PR TITLE
Fix: Incorrect sorting of numeric columns in portfolio

### DIFF
--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -200,18 +200,18 @@ class Portfolio:
                         locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                     return lambda x: locale.strxfrm(x["instrumentId"].lower())
                 case "quantity":
-                    return lambda x: x["netSize"]
+                    return lambda x: Decimal(x["netSize"])
                 case "price":
-                    return lambda x: x["price"]
+                    return lambda x: Decimal(x["price"])
                 case "avgCost":
-                    return lambda x: x["averageBuyIn"]
+                    return lambda x: Decimal(x["averageBuyIn"])
                 case "netValue":
-                    return lambda x: x["netValue"]
+                    return lambda x: Decimal(x["netValue"])
                 case _ as m:
                     print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
-                    return lambda x: x["netValue"]
+                    return lambda x: Decimal(x["netValue"])
         else:
-            return lambda x: x["netValue"]
+            return lambda x: Decimal(x["netValue"])
 
     def portfolio_to_csv(self):
         if self.output is None:


### PR DESCRIPTION
**Problem**
When using the `--sort-by-column` option to sort the portfolio by numeric columns (quantity, price, avgCost, netValue), the values were being sorted alphabetically instead of numerically. This resulted in incorrect ordering, e.g., "10" appearing before "2".

**Root Cause**
The `_get_sort_func()` method was returning the raw values without type conversion. Since these values are stored as strings or Decimal objects in string form, Python's `sorted()` function treated them as strings and performed lexicographic sorting.

**Solution**
Modified `_get_sort_func()` to wrap all numeric column values with `Decimal()` conversion before returning them as sort keys. This ensures proper numeric comparison during sorting.

**Changes**
Updated sort key lambdas for quantity, price, avgCost, and netValue columns
Changed from `lambda x: x["field"]` to `lambda x: Decimal(x["field"])`

**Testing**
Verified with --sort-by-column quantity that positions are now correctly ordered by numeric value.