### PR TITLE
Add ISIN for Amundi MSCI World Merger (SWAP event)

### DIFF
--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -257,6 +257,8 @@ class TransactionExporter:
                 kwargs["isin2"] = "DE000TKMS001"
             elif event.note == "Unilever":
                 kwargs["isin2"] = "GB00BVZK7T90"
+            elif event.note == "MSCI World USD (Acc)" and event.isin == "LU1781541179":
+                kwargs["isin2"] = "IE000BI8OT95"
             else:
                 kwargs["isin2"] = event.note
             kwargs["note"] = event.title


### PR DESCRIPTION
Amundi merged two MSCI World ETFs in Feb. 2025 (LU1781541179 into IE000BI8OT95). Unfortunately, the transaction event does not contain the new ISIN, only the name of the merged ETF. In the app, the ISIN of the new ETF can be obtained from the PDF document attached to the transaction.

Merger announcement see here: https://www.amundietf.co.uk/pdfDocuments/download/f8836e4c-725b-41ec-a93c-09c0a61fb529/NoticeToShareholders_LU1781541179_GBR_ENG_20250115.pdf

