### PR TITLE
Close websocket connection before asyncio.run() terminates

### DIFF
--- a/pytr/alarms.py
+++ b/pytr/alarms.py
@@ -101,6 +101,7 @@ class Alarms:
         while action_count > 0:
             await self.tr.recv()
             action_count -= 1
+        await self.tr.close()
         return
 
     def overview(self):
@@ -151,7 +152,11 @@ class Alarms:
                 except InvalidOperation:
                     raise ValueError(f"{token} is no valid ISIN or decimal value that could represent an alarm.")
 
-        asyncio.run(self.alarms_loop())
+        async def get_alarms_and_close():
+            await self.alarms_loop()
+            await self.tr.close()
+
+        asyncio.run(get_alarms_and_close())
 
         self.overview()
 

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -365,6 +365,13 @@ class TradeRepublicApi:
 
         return self._ws
 
+    async def close(self):
+        """Close the websocket connection gracefully."""
+        if self._ws is not None:
+            self.log.info("Closing websocket connection...")
+            await self._ws.close()
+            self._ws = None
+
     async def _next_subscription_id(self):
         async with self._lock:
             subscription_id = self._subscription_id_counter

--- a/pytr/details.py
+++ b/pytr/details.py
@@ -50,6 +50,7 @@ class Details:
                 print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response, num_lines=30)}")
 
             if recv == 6:
+                await self.tr.close()
                 return
 
     def print_instrument(self):

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -188,6 +188,8 @@ class Portfolio:
                 portfolionew.append(pos)
         self.portfolio = portfolionew
 
+        await self.tr.close()
+
     def _get_sort_func(self):
         if self.sort_by_column:
             match self.sort_by_column.lower():

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -109,6 +109,8 @@ class Timeline:
             else:
                 self.log.warning(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
 
+        await self.tr.close()
+
     async def get_next_timeline_transactions(self, response):
         """
         Get timeline transactions and store them in list timeline_transactions


### PR DESCRIPTION
I've noticed that the websocket connection is not properly closed before asyncio.run() terminates. This resulted in the following error

```
10:27:07 Nothing to download.
Fatal error on SSL transport
protocol: <asyncio.sslproto.SSLProtocol object at 0x722be3ff6c20>
transport: <_SelectorSocketTransport closing fd=9>
Traceback (most recent call last):
  File "asyncio/selector_events.py", line 924, in write
OSError: [Errno 9] Bad file descriptor

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "asyncio/sslproto.py", line 690, in _process_write_backlog
  File "asyncio/selector_events.py", line 930, in write
  File "asyncio/selector_events.py", line 725, in _fatal_error
  File "asyncio/selector_events.py", line 737, in _force_close
  File "asyncio/base_events.py", line 753, in call_soon
  File "asyncio/base_events.py", line 515, in _check_closed
RuntimeError: Event loop is closed
```
This PR added async def close() method to TradeRepublicApi in api.py that gracefully closes the websocket. The new method is now used at the end of each async loop.

Now it shuts down without error.

