### PR TITLE
Fix tax sign in old style events

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -703,6 +703,9 @@ class Event:
             dump_dict["subtitle"] = taxes_dict["title"]
             dump_dict["type"] = "taxes"
             taxes = cls._parse_float_from_text_value(taxes_dict.get("detail", {}).get("text", ""), dump_dict)
+            if taxes_dict.get("title") == "Steuern":
+                # old style event
+                taxes = -taxes
         # no logging here because events may or may not have taxes
 
         if (

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -704,7 +704,6 @@ class Event:
             dump_dict["type"] = "taxes"
             taxes = cls._parse_float_from_text_value(taxes_dict.get("detail", {}).get("text", ""), dump_dict)
             if taxes_dict.get("title") == "Steuern":
-                get_event_logger().info(f"Flip tax sign. {dump_dict}: {taxes} -> {-taxes}")
                 taxes = -taxes
         # no logging here because events may or may not have taxes
 
@@ -778,7 +777,6 @@ class Event:
                 taxes_dict.get("detail", {}).get("text", ""), dump_dict, pref_locale
             )
             if taxes_dict.get("title") == "Steuern":
-                get_event_logger().info(f"Flip tax sign. {dump_dict}: {taxes} -> {-taxes}")
                 taxes = -taxes
         # no logging here because events may or may not have taxes
 

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -704,7 +704,7 @@ class Event:
             dump_dict["type"] = "taxes"
             taxes = cls._parse_float_from_text_value(taxes_dict.get("detail", {}).get("text", ""), dump_dict)
             if taxes_dict.get("title") == "Steuern":
-                # old style event
+                get_event_logger().info(f"Flip tax sign. {dump_dict}: {taxes} -> {-taxes}")
                 taxes = -taxes
         # no logging here because events may or may not have taxes
 
@@ -777,6 +777,9 @@ class Event:
             taxes = cls._parse_float_from_text_value(
                 taxes_dict.get("detail", {}).get("text", ""), dump_dict, pref_locale
             )
+            if taxes_dict.get("title") == "Steuern":
+                get_event_logger().info(f"Flip tax sign. {dump_dict}: {taxes} -> {-taxes}")
+                taxes = -taxes
         # no logging here because events may or may not have taxes
 
         return taxes

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -801,14 +801,14 @@ def test_events():
             "event_type": PPEventType.INTEREST,
             "title": "Zinsen",
             "value": 11.76,
-            "taxes": 4.51,
+            "taxes": -4.51,
             "transactions": [
                 {
                     "Datum": "2024-09-01T16:39:48",
                     "Typ": "Zinsen",
                     "Wert": 11.76,
                     "Notiz": "Zinsen",
-                    "Steuern": -4.51,
+                    "Steuern": 4.51,
                 }
             ],
         },
@@ -817,14 +817,14 @@ def test_events():
             "event_type": PPEventType.INTEREST,
             "title": "Zinsen",
             "value": 11.76,
-            "taxes": 4.51,
+            "taxes": -4.51,
             "transactions": [
                 {
                     "Datum": "2024-09-01T16:39:48",
                     "Typ": "Zinsen",
                     "Wert": 11.76,
                     "Notiz": "Zinsen",
-                    "Steuern": -4.51,
+                    "Steuern": 4.51,
                 }
             ],
         },
@@ -1685,14 +1685,14 @@ def test_events():
             "event_type": PPEventType.INTEREST,
             "title": "Zinsen",
             "value": 4.87,
-            "taxes": 1.87,
+            "taxes": -1.87,
             "transactions": [
                 {
                     "Datum": "2025-07-01T06:46:37",
                     "Typ": "Zinsen",
                     "Wert": 4.87,
                     "Notiz": "Zinsen",
-                    "Steuern": -1.87,
+                    "Steuern": 1.87,
                 }
             ],
         },
@@ -1701,14 +1701,14 @@ def test_events():
             "event_type": PPEventType.INTEREST,
             "title": "Zinsen",
             "value": 4.87,
-            "taxes": 1.87,
+            "taxes": -1.87,
             "transactions": [
                 {
                     "Datum": "2025-07-01T06:46:37",
                     "Typ": "Zinsen",
                     "Wert": 4.87,
                     "Notiz": "Zinsen",
-                    "Steuern": -1.87,
+                    "Steuern": 1.87,
                 }
             ],
         },

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -593,7 +593,7 @@ def test_events():
             "isin": "LU0392494562",
             "shares": 32,
             "value": 30.21,
-            "taxes": 6.83,
+            "taxes": -6.83,
             "transactions": [
                 {
                     "Datum": "2024-12-31T23:59:59",
@@ -602,7 +602,7 @@ def test_events():
                     "Notiz": "MSCI World USD (Dist)",
                     "ISIN": "LU0392494562",
                     "Stück": 32.0,
-                    "Steuern": -6.83,
+                    "Steuern": 6.83,
                 }
             ],
         },


### PR DESCRIPTION
This fixes issue #317 

If you look at the surrounding tests, you'll see that the one I changed didn't match the pattern of the other tests.

Please verify:
- with your own data
- that the handling is implemented in the correct location

Note: this is a breaking change to the existing behavior