### PR TITLE
Cleanup TR login handling, remove app login code and add a method to obtain the AWS WAF token using playwright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "curl_cffi",
     "packaging",
     "pathvalidate",
+    "playwright",
     "pygments",
     "requests_futures",
     "shtab",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "coloredlogs",
     "cryptography",
     "curl_cffi",
-    "ecdsa",
     "packaging",
     "pathvalidate",
     "pygments",

--- a/pytr/account.py
+++ b/pytr/account.py
@@ -5,8 +5,8 @@ from getpass import getpass
 
 from pygments import formatters, highlight, lexers
 
-from pytr.api import CREDENTIALS_FILE, TradeRepublicApi
-from pytr.utils import get_logger
+from .api import BASE_DIR, CREDENTIALS_FILE, TradeRepublicApi
+from .utils import get_logger
 
 
 def get_settings(tr):
@@ -18,9 +18,8 @@ def get_settings(tr):
         return formatted_json
 
 
-def login(phone_no=None, pin=None, web=True, store_credentials=False, waf_token=None):
+def login(phone_no=None, pin=None, store_credentials=False, waf_token=None):
     """
-    If web is true, use web login method, else simulate app login.
     Handle credentials parameters and store to credentials file if requested.
     If no parameters are set but are needed then ask for input
     """
@@ -28,22 +27,18 @@ def login(phone_no=None, pin=None, web=True, store_credentials=False, waf_token=
     save_cookies = True
 
     if phone_no is None and CREDENTIALS_FILE.is_file():
-        log.info("Found credentials file")
         with open(CREDENTIALS_FILE) as f:
             lines = f.readlines()
         phone_no = lines[0].strip()
         pin = lines[1].strip()
         phone_no_masked = phone_no[:-8] + "********"
         pin_masked = len(pin) * "*"
-        log.info(f"Phone: {phone_no_masked}, PIN: {pin_masked}")
+        log.info(f"Using credentials from file {CREDENTIALS_FILE}. Phone: {phone_no_masked}, PIN: {pin_masked}")
     else:
-        CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        BASE_DIR.mkdir(parents=True, exist_ok=True)
         if phone_no is None:
-            log.info("Credentials file not found")
             print("Please enter your TradeRepublic phone number in the format +4912345678:")
             phone_no = input()
-        else:
-            log.info("Phone number provided as argument")
 
         if pin is None:
             print("Please enter your TradeRepublic pin:")
@@ -53,56 +48,36 @@ def login(phone_no=None, pin=None, web=True, store_credentials=False, waf_token=
             with open(CREDENTIALS_FILE, "w") as f:
                 f.writelines([phone_no + "\n", pin + "\n"])
 
-            log.info(f"Saved credentials in {CREDENTIALS_FILE}")
+            log.info(f"Storing credentials/cookies in {BASE_DIR}")
         else:
             save_cookies = False
 
     tr = TradeRepublicApi(phone_no=phone_no, pin=pin, save_cookies=save_cookies, waf_token=waf_token)
 
-    if web:
-        # Use same login as app.traderepublic.com
-        if tr.resume_websession():
-            log.info("Web session resumed")
-        else:
-            try:
-                countdown = tr.initiate_weblogin()
-            except ValueError as e:
-                log.fatal(str(e))
-                sys.exit(1)
-            request_time = time.time()
-            print("Enter the code you received to your mobile app as a notification.")
-            print(f"Enter nothing if you want to receive the (same) code as SMS. (Countdown: {countdown})")
-            code = input("Code: ")
-            if code == "":
-                countdown = countdown - (time.time() - request_time)
-                for remaining in range(int(countdown)):
-                    print(
-                        f"Need to wait {int(countdown - remaining)} seconds before requesting SMS...",
-                        end="\r",
-                    )
-                    time.sleep(1)
-                print()
-                tr.resend_weblogin()
-                code = input("SMS requested. Enter the confirmation code:")
-            tr.complete_weblogin(code)
-    else:
-        # Try to login. Ask for device reset if needed
+    # Use same login as app.traderepublic.com
+    if not tr.resume_websession():
         try:
-            tr.login()
-        except (KeyError, AttributeError):
-            # old keyfile or no keyfile
-            print("Error logging in. Reset device? (y)")
-            confirmation = input()
-            if confirmation == "y":
-                tr.initiate_device_reset()
-                print("You should have received a SMS with a token. Please type it in:")
-                token = input()
-                tr.complete_device_reset(token)
-                print("Reset done")
-            else:
-                print("Cancelling reset")
-                sys.exit(1)
+            countdown = tr.initiate_weblogin()
+        except ValueError as e:
+            log.fatal(str(e))
+            sys.exit(1)
+        request_time = time.time()
+        print("Enter the code you received to your mobile app as a notification.")
+        print(f"Enter nothing if you want to receive the (same) code as SMS. (Countdown: {countdown})")
+        code = input("Code: ")
+        if code == "":
+            countdown = countdown - (time.time() - request_time)
+            for remaining in range(int(countdown)):
+                print(
+                    f"Need to wait {int(countdown - remaining)} seconds before requesting SMS...",
+                    end="\r",
+                )
+                time.sleep(1)
+            print()
+            tr.resend_weblogin()
+            code = input("SMS requested. Enter the confirmation code:")
+        tr.complete_weblogin(code)
+        log.info("Logged in.")
 
-    log.info("Logged in")
-    # log.debug(get_settings(tr))
+    log.debug(get_settings(tr))
     return tr

--- a/pytr/account.py
+++ b/pytr/account.py
@@ -18,7 +18,7 @@ def get_settings(tr):
         return formatted_json
 
 
-def login(phone_no=None, pin=None, store_credentials=False, waf_token=None):
+def login(phone_no=None, pin=None, store_credentials=False, waf_token="playwright"):
     """
     Handle credentials parameters and store to credentials file if requested.
     If no parameters are set but are needed then ask for input

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -30,12 +30,12 @@ import urllib.parse
 import uuid
 from http.cookiejar import Cookie, MozillaCookieJar
 from typing import Any, Dict
-from playwright.sync_api import sync_playwright
 
 import certifi
 import requests
 import websockets
 from curl_cffi import requests as cffi_requests
+from playwright.sync_api import sync_playwright
 
 from pytr.awswaf.aws import AwsWaf
 from pytr.utils import get_logger
@@ -106,34 +106,35 @@ class TradeRepublicApi:
         Get the AWS WAF token, using the awswaf library.
         """
 
+        self.log.info("Retrieving AWS WAF token using awswaf...")
         try:
-            self.log.info("Retrieving AWS WAF token...")
             session = cffi_requests.Session(impersonate="chrome")
             response = session.get(self._waf_login_url)
             m = re.search(r'src="(https://[^"]+/challenge\.js)"', response.text)
             if not m:
-                self.log.warning("challenge.js URL not found in login page")
+                self.log.warning("AWS WAF token not acquired. challenge.js URL not found in login page.")
                 return None
             challenge_js_url = m.group(1)
             waf_endpoint = challenge_js_url.split("https://", 1)[1].rsplit("/challenge.js", 1)[0]
             challenge_js = session.get(challenge_js_url).text
             token = AwsWaf(waf_endpoint, "app.traderepublic.com", challenge_js)()
-            self.log.info("AWS WAF token obtained.")
-            return token
         except Exception:
-            self.log.warning("Failed to get AWS WAF token", exc_info=True)
-            return None
+            self.log.error("Failed to get AWS WAF token.")
+            raise
+
+        if not token:
+            self.log.warning("AWS WAF token not acquired. Value is None.")
+        return token
 
     def _fetch_waf_token_playwright(self, timeout_ms: int = 30000):
         """
-        Get the AWS WAF token from app.traderepublic.com, using a headless
-        Chromium browser via Playwright.
+        Get the AWS WAF token, using a Playwright browser session.
 
         One-time setup needed:
             playwright install chromium
         """
 
-        self.log.info("Fetching WAF token using Playwright...")
+        self.log.info("Retrieving AWS WAF token using Playwright...")
         try:
             with sync_playwright() as p:
                 browser = p.chromium.launch(
@@ -158,14 +159,13 @@ class TradeRepublicApi:
                         break
                     time.sleep(0.5)
                 browser.close()
+        except Exception:
+            self.log.error('Failed to get AWS WAF token. Try running "playwright install chromium"')
+            raise
 
-            if token:
-                self.log.info("WAF token acquired from Playwright session.")
-                return token
-            self.log.warning("Aws-Waf-Token not found, WAF challenge may not have completed.")
-        except Exception as e:
-            self.log.warning("Failed to get AWS WAF token", exc_info=True)
-        return None
+        if not token:
+            self.log.warning("AWS WAF token not acquired. Value is None.")
+        return token
 
     def _set_waf_cookie(self, token: str):
         """Set the aws-waf-token cookie on the web session."""

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -21,8 +21,6 @@
 # SOFTWARE.
 
 import asyncio
-import base64
-import hashlib
 import json
 import pathlib
 import re
@@ -37,8 +35,6 @@ import certifi
 import requests
 import websockets
 from curl_cffi import requests as cffi_requests
-from ecdsa import NIST256p, SigningKey  # type: ignore[import-untyped]
-from ecdsa.util import sigencode_der  # type: ignore[import-untyped]
 
 from pytr.awswaf.aws import AwsWaf
 from pytr.utils import get_logger
@@ -46,24 +42,18 @@ from pytr.utils import get_logger
 home = pathlib.Path.home()
 BASE_DIR = home / ".pytr"
 CREDENTIALS_FILE = BASE_DIR / "credentials"
-KEY_FILE = BASE_DIR / "keyfile.pem"
 COOKIES_FILE = BASE_DIR / "cookies.txt"
 
 
 class TradeRepublicApi:
-    _default_headers = {"User-Agent": "TradeRepublic/Android 30/App Version 1.1.5534"}
-    _default_headers_web = {
+    _default_headers = {
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36"
     }
     _host = "https://api.traderepublic.com"
     _waf_login_url = "https://app.traderepublic.com/login"
-    _weblogin = False
 
-    _refresh_token = None
-    _session_token = None
-    _session_token_expires_at = None
     _process_id = None
-    _web_session_token_expires_at = 0
+    _session_token_expires_at = 0
 
     _ws = None
     _lock = asyncio.Lock()
@@ -74,24 +64,10 @@ class TradeRepublicApi:
     _credentials_file = CREDENTIALS_FILE
     _cookies_file = COOKIES_FILE
 
-    @property
-    def session_token(self):
-        if not self._refresh_token:
-            self.login()
-        elif self._refresh_token and time.time() > self._session_token_expires_at:
-            self.refresh_access_token()
-        return self._session_token
-
-    @session_token.setter
-    def session_token(self, val):
-        self._session_token_expires_at = time.time() + 290
-        self._session_token = val
-
     def __init__(
         self,
         phone_no=None,
         pin=None,
-        keyfile=None,
         locale="de",
         save_cookies=False,
         credentials_file=None,
@@ -101,6 +77,7 @@ class TradeRepublicApi:
         self.log = get_logger(__name__)
         self._locale = locale
         self._save_cookies = save_cookies
+        self._waf_token = waf_token
 
         self._credentials_file = pathlib.Path(credentials_file) if credentials_file else CREDENTIALS_FILE
 
@@ -118,101 +95,16 @@ class TradeRepublicApi:
 
         self._cookies_file = pathlib.Path(cookies_file) if cookies_file else BASE_DIR / f"cookies.{self.phone_no}.txt"
 
-        self.keyfile = keyfile if keyfile else KEY_FILE
-        try:
-            with open(self.keyfile, "rb") as f:
-                self.sk = SigningKey.from_pem(f.read(), hashfunc=hashlib.sha512)
-        except FileNotFoundError:
-            pass
-
         self._websession = requests.Session()
-        self._websession.headers = self._default_headers_web
+        self._websession.headers = self._default_headers
         if self._save_cookies:
             self._websession.cookies = MozillaCookieJar(self._cookies_file)
 
-        self._waf_token = waf_token or self._fetch_waf_token()
-        if self._waf_token:
-            self._set_waf_cookie(self._waf_token)
-
-    def initiate_device_reset(self):
-        self.sk = SigningKey.generate(curve=NIST256p, hashfunc=hashlib.sha512)
-
-        r = requests.post(
-            f"{self._host}/api/v1/auth/account/reset/device",
-            json={"phoneNumber": self.phone_no, "pin": self.pin},
-            headers=self._default_headers,
-        )
-
-        self._process_id = r.json()["processId"]
-
-    def complete_device_reset(self, token):
-        if not self._process_id and not self.sk:
-            raise ValueError("Initiate Device Reset first.")
-
-        pubkey_bytes = self.sk.get_verifying_key().to_string("uncompressed")
-        pubkey_string = base64.b64encode(pubkey_bytes).decode("ascii")
-
-        r = requests.post(
-            f"{self._host}/api/v1/auth/account/reset/device/{self._process_id}/key",
-            json={"code": token, "deviceKey": pubkey_string},
-            headers=self._default_headers,
-        )
-        if r.status_code == 200:
-            with open(self.keyfile, "wb") as f:
-                f.write(self.sk.to_pem())
-
-    def login(self):
-        self.log.info("Logging in")
-        r = self._sign_request(
-            "/api/v1/auth/login",
-            payload={"phoneNumber": self.phone_no, "pin": self.pin},
-        )
-        self._refresh_token = r.json()["refreshToken"]
-        self.session_token = r.json()["sessionToken"]
-
-    def refresh_access_token(self):
-        self.log.info("Refreshing access token")
-        r = self._sign_request("/api/v1/auth/session", method="GET")
-        self.session_token = r.json()["sessionToken"]
-        self.save_websession()
-
-    def _sign_request(self, url_path, payload=None, method="POST"):
-        ts = int(time.time() * 1000)
-        payload_string = json.dumps(payload) if payload else ""
-        signature_payload = f"{ts}.{payload_string}"
-        signature = self.sk.sign(
-            bytes(signature_payload, "utf-8"),
-            hashfunc=hashlib.sha512,
-            sigencode=sigencode_der,
-        )
-        signature_string = base64.b64encode(signature).decode("ascii")
-
-        headers = self._default_headers.copy()
-        headers["X-Zeta-Timestamp"] = str(ts)
-        headers["X-Zeta-Signature"] = signature_string
-        headers["Content-Type"] = "application/json"
-
-        if url_path == "/api/v1/auth/login":
-            pass
-        elif url_path == "/api/v1/auth/session":
-            headers["Authorization"] = f"Bearer {self._refresh_token}"
-        elif self.session_token:
-            headers["Authorization"] = f"Bearer {self.session_token}"
-
-        if self._waf_token and url_path.startswith("/api/v1/auth/"):
-            headers["Cookie"] = f"aws-waf-token={self._waf_token}"
-
-        return requests.request(
-            method=method,
-            url=f"{self._host}{url_path}",
-            data=payload_string,
-            headers=headers,
-        )
-
     def _fetch_waf_token(self):
-        """Fetch AWS WAF token by solving the challenge. Requires pytr[waf] extras."""
+        """Get AWS WAF token by solving the challenge."""
 
         try:
+            self.log.info("Retrieving AWS WAF token...")
             session = cffi_requests.Session(impersonate="chrome")
             response = session.get(self._waf_login_url)
             m = re.search(r'src="(https://[^"]+/challenge\.js)"', response.text)
@@ -223,10 +115,10 @@ class TradeRepublicApi:
             waf_endpoint = challenge_js_url.split("https://", 1)[1].rsplit("/challenge.js", 1)[0]
             challenge_js = session.get(challenge_js_url).text
             token = AwsWaf(waf_endpoint, "app.traderepublic.com", challenge_js)()
-            self.log.info("AWS WAF token obtained automatically")
+            self.log.info("AWS WAF token obtained.")
             return token
-        except Exception as e:
-            self.log.warning(f"Failed to fetch WAF token automatically: {e}")
+        except Exception:
+            self.log.warning("Failed to get AWS WAF token", exc_info=True)
             return None
 
     def _set_waf_cookie(self, token: str):
@@ -252,11 +144,20 @@ class TradeRepublicApi:
         self._websession.cookies.set_cookie(cookie)
 
     def initiate_weblogin(self):
+        self.log.info("Initiating web login...")
+
+        if not self._waf_token:
+            self._waf_token = self._fetch_waf_token()
+        self._set_waf_cookie(self._waf_token)
+
         r = self._websession.post(
             f"{self._host}/api/v1/auth/web/login",
             json={"phoneNumber": self.phone_no, "pin": self.pin},
         )
+        self.log.debug(f"Web login returned: {r.status_code}")
+        r.raise_for_status()
         j = r.json()
+        self.log.debug(f"Web login data: {json.dumps(j, indent=4)}")
         try:
             self._process_id = j["processId"]
         except KeyError:
@@ -281,7 +182,6 @@ class TradeRepublicApi:
         r = self._websession.post(f"{self._host}/api/v1/auth/web/login/{self._process_id}/{verify_code}")
         r.raise_for_status()
         self.save_websession()
-        self._weblogin = True
 
     def save_websession(self):
         # Saves session cookies too (expirydate=0).
@@ -298,31 +198,33 @@ class TradeRepublicApi:
         Use saved cookie file to resume web session
         return success
         """
-        if self._save_cookies is False:
+        self.log.debug("Called resume_websession.")
+
+        # Only attempt to resume if cookies are used and a cookie file exists.
+        if self._save_cookies is False or not self._cookies_file.exists():
             return False
 
-        # Only attempt to load if the cookie file exists.
-        if self._cookies_file.exists():
-            # Loads session cookies too (expirydate=0).
-            self._websession.cookies.load(ignore_discard=True, ignore_expires=True)
-            self._weblogin = True
-            # Re-apply fresh WAF token over any stale one from the cookie file
-            if self._waf_token:
-                self._set_waf_cookie(self._waf_token)
-            try:
-                self.settings()
-            except requests.exceptions.HTTPError:
-                self._weblogin = False
-                return False
-            else:
-                return True
-        return False
+        self.log.info("Trying to resume websession...")
+
+        # Loads session cookies too (expirydate=0).
+        self._websession.cookies.load(ignore_discard=True, ignore_expires=True)
+
+        try:
+            self.log.debug("Calling settings...")
+            self.settings()
+        except requests.exceptions.HTTPError:
+            self.log.info("Resuming websession failed.")
+            self.log.debug("Error calling tr.settings().", exc_info=True)
+            return False
+
+        self.log.info("Websession resumed.")
+        return True
 
     def _web_request(self, url_path, payload=None, method="GET"):
-        if self._web_session_token_expires_at < time.time():
+        if self._session_token_expires_at < time.time():
             r = self._websession.get(f"{self._host}/api/v1/auth/web/session")
             r.raise_for_status()
-            self._web_session_token_expires_at = time.time() + 290
+            self._session_token_expires_at = time.time() + 290
         return self._websession.request(method=method, url=f"{self._host}{url_path}", data=payload)
 
     async def _get_ws(self):
@@ -335,22 +237,21 @@ class TradeRepublicApi:
         connection_message = {"locale": self._locale}
         connect_id = 21
 
-        if self._weblogin:
-            # authenticate with cookies, set different connection message and connect ID
-            cookie_str = ""
-            for cookie in self._websession.cookies:
-                if cookie.domain.endswith("traderepublic.com"):
-                    cookie_str += f"{cookie.name}={cookie.value}; "
-            extra_headers = {"Cookie": cookie_str.rstrip("; ")}
+        # authenticate with cookies, set different connection message and connect ID
+        cookie_str = ""
+        for cookie in self._websession.cookies:
+            if cookie.domain.endswith("traderepublic.com"):
+                cookie_str += f"{cookie.name}={cookie.value}; "
+        extra_headers = {"Cookie": cookie_str.rstrip("; ")}
 
-            connection_message = {
-                "locale": self._locale,
-                "platformId": "webtrading",
-                "platformVersion": "chrome - 94.0.4606",
-                "clientId": "app.traderepublic.com",
-                "clientVersion": "5582",
-            }
-            connect_id = 31
+        connection_message = {
+            "locale": self._locale,
+            "platformId": "webtrading",
+            "platformVersion": "chrome - 94.0.4606",
+            "clientId": "app.traderepublic.com",
+            "clientVersion": "5582",
+        }
+        connect_id = 31
 
         self._ws = await websockets.connect(
             "wss://api.traderepublic.com", ssl=ssl_context, additional_headers=extra_headers
@@ -361,7 +262,7 @@ class TradeRepublicApi:
         if not response == "connected":
             raise ValueError(f"Connection Error: {response}")
 
-        self.log.info("Connected to websocket...")
+        self.log.info("Connected.")
 
         return self._ws
 
@@ -385,8 +286,6 @@ class TradeRepublicApi:
         self.subscriptions[subscription_id] = payload
 
         payload_with_token = payload.copy()
-        if not self._weblogin:
-            payload_with_token["token"] = self.session_token
 
         await ws.send(f"sub {subscription_id} {json.dumps(payload_with_token)}")
         return subscription_id
@@ -805,31 +704,44 @@ class TradeRepublicApi:
         return await self.subscribe({"type": "unsubscribeNews", "instrumentId": isin})
 
     def payout(self, amount):
-        return self._sign_request("/api/v1/payout", {"amount": amount}).json()
+        return requests.request(
+            method="POST",
+            url=f"{self._host}/api/v1/payout",
+            data={"amount": amount},
+            headers=self._default_headers,
+        ).json()
 
     def confirm_payout(self, process_id, code):
-        r = self._sign_request(f"/api/v1/payout/{process_id}/code", {"code": code})
+        r = requests.request(
+            method="POST",
+            url=f"{self._host}/api/v1/payout/{process_id}/code",
+            data={"code": code},
+            headers=self._default_headers,
+        )
+
         if r.status_code != 200:
             raise ValueError(f"Payout failed with response {r.text!r}")
 
     def settings(self):
-        if self._weblogin:
-            r = self._web_request("/api/v2/auth/account")
-        else:
-            r = self._sign_request("/api/v1/auth/account", method="GET")
+        r = self._web_request("/api/v2/auth/account")
         r.raise_for_status()
         return r.json()
 
     def order_cost(self, isin, exchange, order_mode, order_type, size, sell_fractions):
-        url = (
-            f"/api/v1/user/costtransparency?instrumentId={isin}&exchangeId={exchange}"
-            f"&mode={order_mode}&type={order_type}&size={size}&sellFractions={sell_fractions}"
-        )
-        return self._sign_request(url, method="GET").text
+        return requests.request(
+            method="GET",
+            url=f"{self._host}/api/v1/user/costtransparency?instrumentId={isin}&exchangeId={exchange}&mode={order_mode}&type={order_type}&size={size}&sellFractions={sell_fractions}",
+            data=None,
+            headers=self._default_headers,
+        ).text
 
     def savings_plan_cost(self, isin, amount, interval):
-        url = f"/api/v1/user/savingsplancosttransparency?instrumentId={isin}&amount={amount}&interval={interval}"
-        return self._sign_request(url, method="GET").text
+        return requests.request(
+            method="GET",
+            url=f"{self._host}/api/v1/user/savingsplancosttransparency?instrumentId={isin}&amount={amount}&interval={interval}",
+            data=None,
+            headers=self._default_headers,
+        ).text
 
     def __getattr__(self, name):
         if name[:9] == "blocking_":

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -54,7 +54,7 @@ class TradeRepublicApi:
     _waf_login_url = "https://app.traderepublic.com/login"
 
     _process_id = None
-    _session_token_expires_at = 0
+    _session_expires_at = 0
 
     _ws = None
     _lock = asyncio.Lock()
@@ -276,10 +276,10 @@ class TradeRepublicApi:
         return True
 
     def _web_request(self, url_path, payload=None, method="GET"):
-        if self._session_token_expires_at < time.time():
+        if self._session_expires_at < time.time():
             r = self._websession.get(f"{self._host}/api/v1/auth/web/session")
             r.raise_for_status()
-            self._session_token_expires_at = time.time() + 290
+            self._session_expires_at = time.time() + 290
         return self._websession.request(method=method, url=f"{self._host}{url_path}", data=payload)
 
     async def _get_ws(self):

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -30,6 +30,7 @@ import urllib.parse
 import uuid
 from http.cookiejar import Cookie, MozillaCookieJar
 from typing import Any, Dict
+from playwright.sync_api import sync_playwright
 
 import certifi
 import requests
@@ -47,7 +48,7 @@ COOKIES_FILE = BASE_DIR / "cookies.txt"
 
 class TradeRepublicApi:
     _default_headers = {
-        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36"
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
     }
     _host = "https://api.traderepublic.com"
     _waf_login_url = "https://app.traderepublic.com/login"
@@ -72,7 +73,7 @@ class TradeRepublicApi:
         save_cookies=False,
         credentials_file=None,
         cookies_file=None,
-        waf_token=None,
+        waf_token="playwright",
     ):
         self.log = get_logger(__name__)
         self._locale = locale
@@ -100,8 +101,10 @@ class TradeRepublicApi:
         if self._save_cookies:
             self._websession.cookies = MozillaCookieJar(self._cookies_file)
 
-    def _fetch_waf_token(self):
-        """Get AWS WAF token by solving the challenge."""
+    def _fetch_waf_token_awswaf(self):
+        """
+        Get the AWS WAF token, using the awswaf library.
+        """
 
         try:
             self.log.info("Retrieving AWS WAF token...")
@@ -120,6 +123,49 @@ class TradeRepublicApi:
         except Exception:
             self.log.warning("Failed to get AWS WAF token", exc_info=True)
             return None
+
+    def _fetch_waf_token_playwright(self, timeout_ms: int = 30000):
+        """
+        Get the AWS WAF token from app.traderepublic.com, using a headless
+        Chromium browser via Playwright.
+
+        One-time setup needed:
+            playwright install chromium
+        """
+
+        self.log.info("Fetching WAF token using Playwright...")
+        try:
+            with sync_playwright() as p:
+                browser = p.chromium.launch(
+                    headless=True,
+                    args=["--no-sandbox", "--disable-setuid-sandbox"],
+                )
+                context = browser.new_context()
+                page = context.new_page()
+                page.goto(
+                    "https://app.traderepublic.com/login",
+                    wait_until="domcontentloaded",
+                    timeout=timeout_ms,
+                )
+                deadline = time.time() + timeout_ms / 1000
+                token = None
+                while time.time() < deadline:
+                    for c in context.cookies():
+                        if c["name"] == "aws-waf-token":
+                            token = c["value"]
+                            break
+                    if token:
+                        break
+                    time.sleep(0.5)
+                browser.close()
+
+            if token:
+                self.log.info("WAF token acquired from Playwright session.")
+                return token
+            self.log.warning("Aws-Waf-Token not found, WAF challenge may not have completed.")
+        except Exception as e:
+            self.log.warning("Failed to get AWS WAF token", exc_info=True)
+        return None
 
     def _set_waf_cookie(self, token: str):
         """Set the aws-waf-token cookie on the web session."""
@@ -146,9 +192,18 @@ class TradeRepublicApi:
     def initiate_weblogin(self):
         self.log.info("Initiating web login...")
 
-        if not self._waf_token:
-            self._waf_token = self._fetch_waf_token()
-        self._set_waf_cookie(self._waf_token)
+        if self._waf_token == "awswaf":
+            self._waf_token = self._fetch_waf_token_awswaf()
+        elif self._waf_token == "playwright":
+            self._waf_token = self._fetch_waf_token_playwright()
+        elif self._waf_token:
+            self.log.info("Using WAF token from arguments.")
+
+        if self._waf_token:
+            self.log.debug(f"WAF Token: {self._waf_token}")
+            self._set_waf_cookie(self._waf_token)
+        else:
+            self.log.warning("No WAF token available.")
 
         r = self._websession.post(
             f"{self._host}/api/v1/auth/web/login",

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -339,10 +339,7 @@ class TradeRepublicApi:
         ws = await self._get_ws()
         self.log.debug(f"Subscribing: 'sub {subscription_id} {json.dumps(payload)}'")
         self.subscriptions[subscription_id] = payload
-
-        payload_with_token = payload.copy()
-
-        await ws.send(f"sub {subscription_id} {json.dumps(payload_with_token)}")
+        await ws.send(f"sub {subscription_id} {json.dumps(payload)}")
         return subscription_id
 
     async def unsubscribe(self, subscription_id):

--- a/pytr/awswaf/webgl.json
+++ b/pytr/awswaf/webgl.json
@@ -1,9 +1,5 @@
 [
   {
-    "note": "Vendored from https://github.com/xKiian/awswaf",
-    "license": "MIT"
-  },
-  {
     "webgl_unmasked_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M2 Pro, Unspecified Version)",
     "webgl": [
       {

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -79,7 +79,7 @@ def get_main_parser():
     parser_login_args.add_argument("-p", "--pin", help="TradeRepublic pin")
     parser_login_args.add_argument(
         "--waf-token",
-        help="The method to obtain the AWS WAF token. \"playwright\", \"awswaf\" or a manually provided value (e.g. aws-waf-token cookie copied from browser session). The default currently is \"playwright\".",
+        help='AWS WAF token value or the method to obtain it. Values: "playwright", "awswaf" or a token string, e.g. an aws-waf-token cookie captured from a browser session.',
         default="playwright",
     )
     parser_login_args.add_argument(

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -75,7 +75,6 @@ def get_main_parser():
 
     # parent subparser with common login arguments
     parser_login_args = argparse.ArgumentParser(add_help=False)
-    parser_login_args.add_argument("--applogin", help="Use app login instead of  web login", action="store_true")
     parser_login_args.add_argument("-n", "--phone_no", help="TradeRepublic phone number (international format)")
     parser_login_args.add_argument("-p", "--pin", help="TradeRepublic pin")
     parser_login_args.add_argument(
@@ -444,7 +443,6 @@ def main():
         login(
             phone_no=args.phone_no,
             pin=args.pin,
-            web=not args.applogin,
             store_credentials=args.store_credentials,
             waf_token=args.waf_token,
         )
@@ -453,7 +451,6 @@ def main():
             login(
                 phone_no=args.phone_no,
                 pin=args.pin,
-                web=not args.applogin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
             ),
@@ -470,7 +467,6 @@ def main():
             login(
                 phone_no=args.phone_no,
                 pin=args.pin,
-                web=not args.applogin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
             ),
@@ -481,7 +477,6 @@ def main():
             login(
                 phone_no=args.phone_no,
                 pin=args.pin,
-                web=not args.applogin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
             ),
@@ -511,7 +506,6 @@ def main():
             login(
                 phone_no=args.phone_no,
                 pin=args.pin,
-                web=not args.applogin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
             ),
@@ -546,7 +540,6 @@ def main():
                 login(
                     phone_no=args.phone_no,
                     pin=args.pin,
-                    web=not args.applogin,
                     store_credentials=args.store_credentials,
                     waf_token=args.waf_token,
                 ),
@@ -562,7 +555,6 @@ def main():
                 login(
                     phone_no=args.phone_no,
                     pin=args.pin,
-                    web=not args.applogin,
                     store_credentials=args.store_credentials,
                     waf_token=args.waf_token,
                 ),

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -79,8 +79,8 @@ def get_main_parser():
     parser_login_args.add_argument("-p", "--pin", help="TradeRepublic pin")
     parser_login_args.add_argument(
         "--waf-token",
-        help="Manually provide an aws-waf-token cookie value (copy from browser session)",
-        default=None,
+        help="The method to obtain the AWS WAF token. \"playwright\", \"awswaf\" or a manually provided value (e.g. aws-waf-token cookie copied from browser session). The default currently is \"playwright\".",
+        default="playwright",
     )
     parser_login_args.add_argument(
         "--store_credentials",


### PR DESCRIPTION
This PR improves TR log in handling, fixes a few bugs and removes the app login.

In detail:
- The app login coding is removed since it seems that it has been broken for a while and nobody found a way to make it work again, as per #250 and #274. web login is the (only) way to go. This will also remove the dependency to ecdsa, as requested in #249 
- handling of resuming existing web sessions was cleaned up
- AWS WAF token is only generated and sent during web log in. It seems it is not needed for resumed sessions.
- An issue with webgl.json has been fixed which came due to an addition of the license information
- some logging/output was improved
