### PR TITLE
Add TAX_YEAR_END_REPORT_CREATED to known events

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -43,6 +43,7 @@ event_subfolder_mapping = {
     "SHAREBOOKING_TRANSACTIONAL": "Misc",
     "STOCK_PERK_REFUNDED": "Misc",
     "TAX_YEAR_END_REPORT": "Misc",
+    "TAX_YEAR_END_REPORT_CREATED": "Misc",
     "YEAR_END_TAX_REPORT": "Misc",
     "crypto_annual_statement": "Misc",
     "private_markets_suitability_quiz_completed": "Misc",

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -195,6 +195,7 @@ events_known_ignored = [
     "SHAREBOOKING_TRANSACTIONAL",
     "STOCK_PERK_REFUNDED",
     "TAX_YEAR_END_REPORT",
+    "TAX_YEAR_END_REPORT_CREATED",
     "VERIFICATION_TRANSFER_ACCEPTED",
     "YEAR_END_TAX_REPORT",
     "card_failed_verification",


### PR DESCRIPTION
New Trade Republic event type for annual tax report ("Steuerbericht"). Added to events_known_ignored and event_subfolder_mapping so the PDF is downloaded into Misc/ without triggering an unknown event warning.

Fixes https://github.com/pytr-org/pytr/issues/328