### PR TITLE
fix: avoid crash for private market events without value

### DIFF
--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -218,7 +218,10 @@ class TransactionExporter:
             elif event.isin == "LU3170240538":
                 kwargs["note"] = "Apollo"
 
-            assert event.value is not None, event
+            if event.value is None:
+                self._log.warning("Skipping private markets event without value: %s", event)
+                return
+
             kwargs["type"] = self._translate((PPEventType.BUY if event.value < 0 else PPEventType.SELL).value)
             if event.note == "1 % Bonus":
                 yield self._localize_keys(kwargs)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 
 from pytr.event import ConditionalEventType, Event, PPEventType
 from pytr.transactions import TransactionExporter
@@ -1882,3 +1883,22 @@ def test_events():
             entry.setdefault("ISIN2", None)
             entry.setdefault("Stück2", None)
         assert transactions == rowtransactions
+
+
+def test_private_markets_order_without_value_is_skipped():
+    formatter = TransactionExporter(lang="de")
+    event = Event(
+        event_type=ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        date=datetime(2026, 3, 9, 7, 56, 12, tzinfo=timezone.utc),
+        title="Private Equity",
+        isin="LU3176111881",
+        isin2=None,
+        shares=0,
+        shares2=None,
+        value=None,
+        fees=None,
+        taxes=None,
+        note="Vorabpauschale",
+    )
+
+    assert list(formatter.from_event(event)) == []


### PR DESCRIPTION
Fixes #322

Some private market timeline events (for example Vorabpauschale entries) have no monetary value. The exporter currently asserts on those events and aborts the whole export.

This change skips only the malformed private-market event, logs a warning, and continues exporting the remaining transactions. Added a regression test for this case.

Greetings, saschabuehrle