### PR TITLE
Misc fixes and improvements

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -247,6 +247,7 @@ events_known_ignored_subtitle = [
     "Sparplan fehlgeschlagen",
     "Stop-Market Verkauf-Abrechnung storniert",
     "Stop-Sell-Order storniert",
+    "Teilnehmen?",
     "Verkaufsorder abgelehnt",
 ]
 
@@ -288,7 +289,14 @@ class Event:
         ts = ts[:-2] + ":" + ts[-2:]
         date: datetime = datetime.fromisoformat(ts)
         title: str = event_dict["title"]
+        isin: Optional[str] = None
         isin2: Optional[str] = None
+        shares: Optional[float] = None
+        shares2: Optional[float] = None
+        value: Optional[float] = None
+        fees: Optional[float] = None
+        taxes: Optional[float] = None
+        note: Optional[str] = None
         subtitle = event_dict["subtitle"]
         eventdesc = f"{title} {subtitle} ({event_dict['id']})"
         sections = event_dict.get("details", {}).get("sections", [{}])
@@ -415,6 +423,9 @@ class Event:
             ignoreEvent = True
         if title == "E-Mail" and subtitle == "Bestätigt":
             ignoreEvent = True
+        if eventTypeStr == "PRIVATE_MARKET_FUND_ORDER_RECEIVED":
+            event_type = None
+            ignoreEvent = True
 
         if event_type is not None and event_dict.get("status", "").lower() == "canceled":
             event_type = None
@@ -428,31 +439,8 @@ class Event:
             get_event_logger().warning(f'Ignoring unknown event "{eventdesc}"')
             get_event_logger().debug("Unknown event %s: %s", eventdesc, json.dumps(event_dict, indent=4))
 
-        isin, shares, shares2, value, fees, taxes, note = cls._parse_type_dependent_params(event_type, event_dict)
-        return cls(event_type, date, title, isin, isin2, shares, shares2, value, fees, taxes, note)
-
-    @classmethod
-    def _parse_type_dependent_params(
-        cls, event_type: Optional[EventType], event_dict: Dict[Any, Any]
-    ) -> Tuple[
-        Optional[str],
-        Optional[float],
-        Optional[float],
-        Optional[float],
-        Optional[float],
-        Optional[float],
-        Optional[str],
-    ]:
-        """Parses the isin, shares, value, fees, taxes and note fields
-
-        Args:
-            event_type (EventType): _description_
-            event_dict (Dict[Any, Any]): _description_
-
-        Returns:
-            Tuple[Optional[Union[str, float]]]]: isin, shares, shares2, value, fees, taxes, note
-        """
-        isin, shares, shares2, value, fees, taxes, note = (None,) * 7
+        if event_type is None:
+            return cls(event_type, date, title, isin, isin2, shares, shares2, value, fees, taxes, note)
 
         if isinstance(event_type, ConditionalEventType) or event_type in [
             PPEventType.DIVIDEND,
@@ -471,7 +459,20 @@ class Event:
             elif event_type in [PPEventType.DEPOSIT, PPEventType.REMOVAL]:
                 note = cls._parse_card_note(event_dict)
 
-        return isin, shares, shares2, value, fees, taxes, note
+        if event_type is PPEventType.SWAP and uebersicht_dict:
+            foundentfernt = False
+            for item in uebersicht_dict.get("data", []):
+                ititle = item.get("title")
+                if ititle == "Aktien entfernt":
+                    foundentfernt = True
+            if not foundentfernt:
+                event_type = ConditionalEventType.TRADE_INVOICE
+                if title == "WORLDLINE S.A. ANR":
+                    title = "Worldline"
+                    isin = "FR0011981968"
+                    note = None
+
+        return cls(event_type, date, title, isin, isin2, shares, shares2, value, fees, taxes, note)
 
     @staticmethod
     def _parse_isin(event_dict: Dict[Any, Any]) -> str:
@@ -536,8 +537,7 @@ class Event:
             wertpapier_dict,
             wertpapier_dict2,
             quotation_dict,
-            order_dict,
-        ) = (None,) * 15
+        ) = (None,) * 14
 
         value: Optional[float] = v if (v := event_dict.get("amount", {}).get("value", None)) is not None else None
 
@@ -559,7 +559,7 @@ class Event:
             fees_dict = next(filter(lambda x: x["title"] == "Gebühr", data), None)
             taxes_dict = next(filter(lambda x: x["title"] in ["Steuer", "Steuern"], data), None)
 
-        uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht"], sections), None)
+        uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht", "Overview"], sections), None)
         if uebersicht_dict:
             # new style event
             for item in uebersicht_dict.get("data", []):
@@ -570,15 +570,13 @@ class Event:
                     taxes_dict = item
                 elif ititle == "Gesamt":
                     gesamt_dict = item
-                elif ititle == "Aktien entfernt" and not shares_dict:
-                    shares_dict = item
-                elif ititle == "Wertpapier" and not wertpapier_dict:
+                elif ititle in ["Wertpapier", "Asset"] and not wertpapier_dict:
                     wertpapier_dict = item
-                elif ititle == "Wertpapier" and wertpapier_dict and not wertpapier_dict2:
+                elif ititle in ["Wertpapier", "Asset"] and wertpapier_dict and not wertpapier_dict2:
                     wertpapier_dict2 = item
-                elif ititle == "Aktien hinzugefügt" and not shares_dict:
+                elif ititle in ["Aktien entfernt", "Aktien hinzugefügt", "Shares"] and not shares_dict:
                     shares_dict = item
-                elif ititle == "Aktien hinzugefügt" and shares_dict and not shares_dict2:
+                elif ititle in ["Aktien entfernt", "Aktien hinzugefügt", "Shares"] and shares_dict and not shares_dict2:
                     shares_dict2 = item
                 elif ititle == "Transaktion" and not transaction_dict:
                     transaction_dict = item
@@ -591,8 +589,6 @@ class Event:
                                     shares_dict = subitem
                                 elif subitem.get("title") == "Quotation" and not quotation_dict:
                                     quotation_dict = subitem
-                                elif subitem.get("title") == "Order" and not order_dict:
-                                    order_dict = subitem
 
         if shares_dict:
             dump_dict["subtitle"] = shares_dict["title"]
@@ -617,7 +613,7 @@ class Event:
                         "Zusammenschluss",
                     ]
                 )
-                and shares_dict["title"] in ["Aktien", "Aktien hinzugefügt", "Aktien entfernt"]
+                and shares_dict["title"] in ["Aktien", "Aktien hinzugefügt", "Aktien entfernt", "Shares"]
                 else "de"
             )
             shares = cls._parse_float_from_text_value(
@@ -628,12 +624,14 @@ class Event:
                 shares2 = cls._parse_float_from_text_value(
                     shares_dict2.get("detail", {}).get("text", ""), dump_dict, pref_locale
                 )
-        elif order_dict and quotation_dict:
-            order = cls._parse_float_from_text_value(order_dict.get("detail", {}).get("text", ""), dump_dict)
+        elif transaction_dict and quotation_dict:
+            transaction = cls._parse_float_from_text_value(
+                transaction_dict.get("detail", {}).get("text", ""), dump_dict
+            )
             quotation = cls._parse_float_from_text_value(quotation_dict.get("detail", {}).get("text", ""), dump_dict)
-            if order and quotation:
+            if transaction and quotation:
                 shares = float(
-                    (Decimal(order) / Decimal(quotation) * Decimal(100)).quantize(
+                    (Decimal(transaction) / Decimal(quotation) * Decimal(100)).quantize(
                         Decimal("0.01"), rounding=ROUND_HALF_UP
                     )
                 )

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -110,17 +110,27 @@ class Portfolio:
 
             await self.tr.unsubscribe(subscription_id)
 
+        # a way to ignore instruments from portfolio
+        # e.g. set to ["US30303M1027"] if you want to exclude Meta Platforms (A)
+        # this should be exposed as a parameter...
+        instruments_to_ignore = []
+
         isins = set()
+        portfolio = list()
         for pos in self.portfolio:
-            isins.add(pos["instrumentId"])
+            if pos["instrumentId"] not in instruments_to_ignore:
+                portfolio.append(pos)
+                isins.add(pos["instrumentId"])
+        self.portfolio = portfolio
 
         # extend portfolio with watchlist elements
         if self.watchlist:
             for pos in self.watchlist:
-                isin = pos["instrumentId"]
-                if isin not in isins:
-                    isins.add(isin)
-                    self.portfolio.append(pos)
+                if pos["instrumentId"] not in instruments_to_ignore:
+                    isin = pos["instrumentId"]
+                    if isin not in isins:
+                        isins.add(isin)
+                        self.portfolio.append(pos)
 
         # Populate name for each ISIN
         subscriptions = {}

--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -194,6 +194,8 @@ class TransactionExporter:
                 kwargs["isin"] = "DE000TKMS001"
             elif event.note == "Unilever":
                 kwargs["isin"] = "GB00BVZK7T90"
+            elif event.note == "Worldline":
+                kwargs["isin"] = "FR0014015MS9"
             else:
                 kwargs["isin"] = event.isin2
             if event.shares2:
@@ -263,6 +265,8 @@ class TransactionExporter:
                 kwargs["isin2"] = "GB00BVZK7T90"
             elif event.note == "MSCI World USD (Acc)" and event.isin == "LU1781541179":
                 kwargs["isin2"] = "IE000BI8OT95"
+            elif event.note == "Worldline":
+                kwargs["isin2"] = "FR0011981968"
             else:
                 kwargs["isin2"] = event.note
             kwargs["note"] = event.title

--- a/tests/aktien_entfernt2.json
+++ b/tests/aktien_entfernt2.json
@@ -1,0 +1,96 @@
+  {
+    "id": "6919f8d9-e168-321f-b276-8766ce50f319",
+    "timestamp": "2026-04-03T10:48:40.913+0000",
+    "title": "WORLDLINE S.A. ANR",
+    "icon": "logos/FR0014015MS9/v2",
+    "subtitle": "Wertlos",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "6919f8d9-e168-321f-b276-8766ce50f319"
+    },
+    "eventType": "SSP_CORPORATE_ACTION_NO_CASH",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineActivity",
+    "details": {
+      "id": "6919f8d9-e168-321f-b276-8766ce50f319",
+      "sections": [
+        {
+          "title": "Aktien wurden im Rahmen einer Kapitalmaßnahme entfernt",
+          "data": {
+            "icon": {
+              "asset": "logos/FR0014015MS9/v2",
+              "badge": null
+            },
+            "timestamp": "2026-04-03T10:48:40.913Z",
+            "status": "executed"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Status",
+              "detail": {
+                "text": "Ausgeführt",
+                "functionalStyle": "EXECUTED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Orderart",
+              "detail": {
+                "text": "Wertlos",
+                "displayValue": {
+                  "text": "Wertlos"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Wertpapier",
+              "detail": {
+                "text": "WORLDLINE S.A. ANR",
+                "displayValue": {
+                  "text": "WORLDLINE S.A. ANR"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Aktien entfernt",
+              "detail": {
+                "text": "0.299376",
+                "displayValue": {
+                  "text": "0.299376"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Dokumente",
+              "detail": "03.04.2026",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "806617db-1080-4301-8768-a87bf909f896",
+              "postboxType": "CA_SECURITIES_INVOICE"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/bond_kauf.json
+++ b/tests/bond_kauf.json
@@ -1,0 +1,242 @@
+  {
+    "id": "6c7755f0-0943-422b-b9ba-bfd9c105584a",
+    "timestamp": "2025-07-18T08:04:42.708+0000",
+    "title": "Juli 2040",
+    "icon": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+    "avatar": {
+      "asset": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+      "badge": null
+    },
+    "badge": null,
+    "subtitle": "Kauforder",
+    "amount": {
+      "currency": "EUR",
+      "value": -100.99,
+      "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "6c7755f0-0943-422b-b9ba-bfd9c105584a"
+    },
+    "cashAccountNumber": "123456789",
+    "hidden": false,
+    "deleted": false,
+    "eventType": "TRADING_TRADE_EXECUTED",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "6c7755f0-0943-422b-b9ba-bfd9c105584a",
+      "sections": [
+        {
+          "title": "Du hast 100,99 € investiert",
+          "data": {
+            "icon": {
+              "asset": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+              "badge": null
+            },
+            "timestamp": "2025-07-18T08:04:42.70813202Z",
+            "status": "executed"
+          },
+          "action": {
+            "payload": "DE0001135366",
+            "type": "instrumentDetail"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Kauf",
+              "detail": {
+                "text": "Ausgeführt",
+                "functionalStyle": "EXECUTED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Asset",
+              "detail": {
+                "text": "Juli 2040",
+                "displayValue": {
+                  "text": "Juli 2040"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Transaktion",
+              "detail": {
+                "text": "99,80 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {
+                        "title": "Transaktion",
+                        "type": "title"
+                      },
+                      {
+                        "data": [
+                          {
+                            "title": "Nennwert",
+                            "detail": {
+                              "text": "82,00 €",
+                              "displayValue": {
+                                "text": "82,00 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Quotation",
+                            "detail": {
+                              "text": "121,31 %",
+                              "displayValue": {
+                                "text": "121,31 %"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Stückzinsen",
+                            "detail": {
+                              "text": "0,19 €",
+                              "displayValue": {
+                                "text": "0,19 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Summe",
+                            "detail": {
+                              "text": "100,99 €",
+                              "displayValue": {
+                                "text": "100,99 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "highlighted"
+                          }
+                        ],
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "displayMode": "bottomSheet",
+                  "type": "infoPage"
+                },
+                "displayValue": {
+                  "text": "99,80 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Gebühr",
+              "detail": {
+                "text": "1,00 €",
+                "displayValue": {
+                  "text": "1,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Summe",
+              "detail": {
+                "text": "100,99 €",
+                "displayValue": {
+                  "text": "100,99 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Performance",
+          "data": [
+            {
+              "title": "Rendite",
+              "detail": {
+                "text": "0,19 %",
+                "trend": "negative",
+                "displayValue": {
+                  "text": "0,19 %"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Verlust",
+              "detail": {
+                "text": "-0,19 €",
+                "trend": "negative",
+                "displayValue": {
+                  "text": "-0,19 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "horizontalTable"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Kosteninformation 1",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "705597e0-f359-4f1e-bd46-ed128d12d620",
+              "postboxType": "EQUITIES_BUY_EX_ANTE"
+            },
+            {
+              "title": "Kosteninformation 2",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "ca3d15ea-d560-4bc8-85a8-73dd81ef7579",
+              "postboxType": "EQUITIES_BUY_EX_ANTE"
+            },
+            {
+              "title": "Abrechnung 1",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "e337f3cc-2cc4-446b-99ce-7ab1b41f66a9",
+              "postboxType": "SECURITIES_SETTLEMENT"
+            },
+            {
+              "title": "Abrechnung 2",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "1ef2976f-118e-4c79-8cb0-3da858fb291d",
+              "postboxType": "SECURITIES_SETTLEMENT"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/bond_verkauf.json
+++ b/tests/bond_verkauf.json
@@ -1,0 +1,323 @@
+  {
+    "id": "e45b8873-16ce-440d-ae96-a4586cfdf9ca",
+    "timestamp": "2026-03-26T06:48:09.708+0000",
+    "title": "Juli 2040",
+    "icon": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+    "avatar": {
+      "asset": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+      "badge": null
+    },
+    "badge": null,
+    "subtitle": "Verkaufsorder",
+    "amount": {
+      "currency": "EUR",
+      "value": 98.21,
+      "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "e45b8873-16ce-440d-ae96-a4586cfdf9ca"
+    },
+    "cashAccountNumber": "123456789",
+    "hidden": false,
+    "deleted": false,
+    "eventType": "TRADING_TRADE_EXECUTED",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "e45b8873-16ce-440d-ae96-a4586cfdf9ca",
+      "sections": [
+        {
+          "title": "Du hast 98,21 € erhalten",
+          "data": {
+            "icon": {
+              "asset": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+              "badge": null
+            },
+            "timestamp": "2026-03-26T06:48:09.708126976Z",
+            "status": "executed"
+          },
+          "action": {
+            "payload": "DE0001135366",
+            "type": "instrumentDetail"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Verkaufen",
+              "detail": {
+                "text": "Ausgeführt",
+                "functionalStyle": "EXECUTED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Asset",
+              "detail": {
+                "text": "Juli 2040",
+                "displayValue": {
+                  "text": "Juli 2040"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Transaktion",
+              "detail": {
+                "text": "96,33 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {
+                        "title": "Transaktion",
+                        "type": "title"
+                      },
+                      {
+                        "data": [
+                          {
+                            "title": "Nennwert",
+                            "detail": {
+                              "text": "0,27 €",
+                              "displayValue": {
+                                "text": "0,27 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Quotation",
+                            "detail": {
+                              "text": "117,09 %",
+                              "displayValue": {
+                                "text": "117,09 %"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Stückzinsen",
+                            "detail": {
+                              "text": "+ 2,88 €",
+                              "displayValue": {
+                                "text": "+ 2,88 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Summe",
+                            "detail": {
+                              "text": "+ 98,21 €",
+                              "displayValue": {
+                                "text": "+ 98,21 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "highlighted"
+                          }
+                        ],
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "displayMode": "bottomSheet",
+                  "type": "infoPage"
+                },
+                "displayValue": {
+                  "text": "96,33 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Steuer",
+              "detail": {
+                "text": "0,00 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {
+                        "title": "Gezahlte Steuern 0,00 €",
+                        "data": {
+                          "icon": {
+                            "asset": "logos/bondissuer-529900AQBND3S6YJLY83/v2",
+                            "badge": null
+                          },
+                          "timestamp": "2026-03-26T06:48:09.708126976Z",
+                          "status": "executed"
+                        },
+                        "action": {
+                          "payload": "DE0001135366",
+                          "type": "instrumentDetail"
+                        },
+                        "type": "header"
+                      },
+                      {
+                        "title": "Steuerbemessungsgrundlage",
+                        "data": [
+                          {
+                            "title": "Bruttogewinn",
+                            "detail": {
+                              "text": "0,00 €",
+                              "displayValue": {
+                                "text": "0,00 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          },
+                          {
+                            "title": "Summe",
+                            "detail": {
+                              "text": "0,00 €",
+                              "displayValue": {
+                                "text": "0,00 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "highlighted"
+                          }
+                        ],
+                        "type": "table"
+                      },
+                      {
+                        "title": "Steuern",
+                        "data": [
+                          {
+                            "title": "Summe",
+                            "detail": {
+                              "text": "0,00 €",
+                              "displayValue": {
+                                "text": "0,00 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "highlighted"
+                          }
+                        ],
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "displayMode": "modal",
+                  "type": "infoPage"
+                },
+                "displayValue": {
+                  "text": "0,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Gebühr",
+              "detail": {
+                "text": "1,00 €",
+                "displayValue": {
+                  "text": "1,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Summe",
+              "detail": {
+                "text": "98,21 €",
+                "displayValue": {
+                  "text": "98,21 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Performance",
+          "data": [
+            {
+              "title": "Rendite",
+              "detail": {
+                "text": "2,65 %",
+                "trend": "negative",
+                "displayValue": {
+                  "text": "2,65 %"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Verlust",
+              "detail": {
+                "text": "-2,59 €",
+                "trend": "negative",
+                "displayValue": {
+                  "text": "-2,59 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "horizontalTable"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Abrechnung 1",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "3713df09-15f0-49ac-859b-da60279ffdb9",
+              "postboxType": "SECURITIES_SETTLEMENT"
+            },
+            {
+              "title": "Abrechnung 2",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "e71c5516-f6dc-495b-9666-b54b6e618cf4",
+              "postboxType": "SECURITIES_SETTLEMENT"
+            },
+            {
+              "title": "Kosteninformation 1",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "15ae9c44-e002-495e-9c21-93e07ede2a64",
+              "postboxType": "EQUITIES_SELL_EX_ANTE"
+            },
+            {
+              "title": "Kosteninformation 2",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "d616495a-e777-4e72-877d-4663b9b52cbf",
+              "postboxType": "EQUITIES_SELL_EX_ANTE"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/private_markets_verkaufs_order_erstellt.json
+++ b/tests/private_markets_verkaufs_order_erstellt.json
@@ -1,0 +1,183 @@
+{
+    "id": "86417e07-754d-45a6-a429-72c1437bc159",
+    "timestamp": "2026-03-26T06:48:51.517+0000",
+    "title": "Private Equity",
+    "icon": "logos/LU3176111881/v2",
+    "subtitle": "Verkaufsorder",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "86417e07-754d-45a6-a429-72c1437bc159"
+    },
+    "eventType": "PRIVATE_MARKET_FUND_ORDER_RECEIVED",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineActivity",
+    "details": {
+      "id": "86417e07-754d-45a6-a429-72c1437bc159",
+      "sections": [
+        {
+          "title": "Du erhältst 104,10 €",
+          "data": {
+            "icon": {
+              "asset": "logos/LU3176111881/v2",
+              "badge": null
+            },
+            "timestamp": "2026-03-26T06:48:51.517335Z",
+            "status": "executed"
+          },
+          "action": {
+            "payload": "LU3176111881",
+            "type": "instrumentDetail"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Order erstellt",
+          "description": "Ausführung bis 9 Juni geplant. Der Betrag ist abhängig vom Fondskurs zum Ausführungszeitpunkt. Eine Ausführung kann nicht garantiert werden.",
+          "type": "banner"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Verkaufen",
+              "detail": {
+                "text": "Erstellt",
+                "functionalStyle": "CREATED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Asset",
+              "detail": {
+                "text": "Private Equity",
+                "displayValue": {
+                  "text": "Private Equity"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Transaktion",
+              "detail": {
+                "text": "106,10 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {
+                        "title": "Transaktion",
+                        "type": "title"
+                      },
+                      {
+                        "data": [
+                          {
+                            "title": "Summe",
+                            "detail": {
+                              "text": "106,10 €",
+                              "displayValue": {
+                                "text": "106,10 €"
+                              },
+                              "type": "text"
+                            },
+                            "style": "plain"
+                          }
+                        ],
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "displayMode": "bottomSheet",
+                  "type": "infoPage"
+                },
+                "displayValue": {
+                  "text": "106,10 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Abzug für 1 %-Bonus",
+              "detail": {
+                "text": "1,00 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {
+                        "title": "Abzug für 1 %-Bonus",
+                        "type": "title"
+                      },
+                      {
+                        "text": "Du hast einen Bonus erhalten, der abgezogen werden muss, da du vor 18 Sept. 2027 verkaufst.",
+                        "type": "text"
+                      }
+                    ]
+                  },
+                  "displayMode": "bottomSheet",
+                  "type": "infoPage"
+                },
+                "displayValue": {
+                  "text": "1,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Gebühr",
+              "detail": {
+                "text": "1,00 €",
+                "displayValue": {
+                  "text": "1,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Summe",
+              "detail": {
+                "text": "104,10 €",
+                "displayValue": {
+                  "text": "104,10 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Löschen",
+          "data": {
+            "title": "Löschen",
+            "action": {
+              "payload": "b7a2dcd2-daf5-4c4b-9f05-7f8b36a54136",
+              "type": "deletePrivateMarketsOrder"
+            }
+          },
+          "type": "actionButtons"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Kosteninformation",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "b5ac9e63-b975-4a94-93dc-5652c0333522",
+              "postboxType": "EQUITIES_SELL_EX_ANTE"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -43,6 +43,24 @@ def test_events():
             ],
         },
         {
+            "filename": "aktien_entfernt2.json",
+            "event_type": ConditionalEventType.TRADE_INVOICE,
+            "title": "WORLDLINE S.A. ANR",
+            "isin": "FR0014015MS9",
+            "shares": 0.299376,
+            "value": 0,
+            "transactions": [
+                {
+                    "Datum": "2026-04-03T10:48:40",
+                    "Typ": "Verkauf",
+                    "Wert": 0,
+                    "Notiz": "WORLDLINE S.A. ANR",
+                    "ISIN": "FR0014015MS9",
+                    "Stück": 0.299376,
+                }
+            ],
+        },
+        {
             "filename": "aktienbonus.json",
             "event_type": ConditionalEventType.SAVEBACK,
             "title": "Aktien-Bonus",
@@ -405,6 +423,46 @@ def test_events():
                     "Notiz": "BYD",
                     "ISIN": "CNE100000296",
                     "Steuern": 8.67,
+                }
+            ],
+        },
+        {
+            "filename": "bond_kauf.json",
+            "event_type": ConditionalEventType.TRADE_INVOICE,
+            "title": "Juli 2040",
+            "isin": "DE0001135366",
+            "shares": 82.27,
+            "value": -100.99,
+            "fees": 1.0,
+            "transactions": [
+                {
+                    "Datum": "2025-07-18T08:04:42",
+                    "Typ": "Kauf",
+                    "Wert": -100.99,
+                    "Notiz": "Juli 2040",
+                    "ISIN": "DE0001135366",
+                    "Stück": 82.27,
+                    "Gebühren": -1.0,
+                }
+            ],
+        },
+        {
+            "filename": "bond_verkauf.json",
+            "event_type": ConditionalEventType.TRADE_INVOICE,
+            "title": "Juli 2040",
+            "isin": "DE0001135366",
+            "shares": 82.27,
+            "value": 98.21,
+            "fees": 1.0,
+            "transactions": [
+                {
+                    "Datum": "2026-03-26T06:48:09",
+                    "Typ": "Verkauf",
+                    "Wert": 98.21,
+                    "Notiz": "Juli 2040",
+                    "ISIN": "DE0001135366",
+                    "Stück": 82.27,
+                    "Gebühren": -1.0,
                 }
             ],
         },
@@ -1213,6 +1271,9 @@ def test_events():
             ],
         },
         {
+            "filename": "private_markets_verkaufs_order_erstellt.json",
+        },
+        {
             "filename": "reverse_split.json",
             "event_type": PPEventType.SWAP,
             "title": "Globalstar",
@@ -1779,6 +1840,46 @@ def test_events():
             ],
         },
         {
+            "filename": "zwischenpapiere2.json",
+            "event_type": PPEventType.SWAP,
+            "title": "WORLDLINE S.A. ANR",
+            "isin": "FR0014015MS9",
+            "shares": 1,
+            "shares2": 6,
+            "value": -1.21,
+            "note": "Worldline",
+            "transactions": [
+                {
+                    "Datum": "2026-04-03T09:37:06",
+                    "Typ": "Swap",
+                    "Wert": -1.21,
+                    "ISIN": "FR0014015MS9",
+                    "Notiz": "WORLDLINE S.A. ANR",
+                    "Stück": 1.0,
+                    "ISIN2": "FR0011981968",
+                    "Stück2": 6.0,
+                },
+            ],
+        },
+        {
+            "filename": "zwischenpapiere3.json",
+            "event_type": ConditionalEventType.TRADE_INVOICE,
+            "title": "Worldline",
+            "isin": "FR0011981968",
+            "shares": 1294,
+            "value": -261.39,
+            "transactions": [
+                {
+                    "Datum": "2026-04-03T10:38:58",
+                    "Typ": "Kauf",
+                    "Wert": -261.39,
+                    "ISIN": "FR0011981968",
+                    "Notiz": "Worldline",
+                    "Stück": 1294.0,
+                },
+            ],
+        },
+        {
             "filename": "zwischenpapiere_no_eventType.json",
             "event_type": PPEventType.SWAP,
             "title": "ORSTED A/S   -ANR-",
@@ -1840,6 +1941,26 @@ def test_events():
                 }
             ],
         },
+        {
+            "filename": "zwischenvertrieb2.json",
+            "event_type": PPEventType.SPINOFF,
+            "title": "Worldline",
+            "isin": "FR0011981968",
+            "shares": 1.299376,
+            "value": 0,
+            "note": "Worldline",
+            "transactions": [
+                {
+                    "Datum": "2026-03-17T10:45:33",
+                    "Typ": "Spinoff",
+                    "Wert": 0,
+                    "Notiz": "Worldline",
+                    "ISIN": "FR0014015MS9",
+                    "Stück": 1.299376,
+                    "ISIN2": "FR0011981968",
+                }
+            ],
+        },
     ]
 
     # Create an instance of EventCsvFormatter
@@ -1853,8 +1974,14 @@ def test_events():
         # Parse the JSON data using the from_dict function
         event = Event.from_dict(sample_data)
 
-        # Assert the expected values
+        # Assert event type
         assert event.event_type == row.get("event_type")
+
+        # if event type is none, nothing else is to check, results will be discarded
+        if row.get("event_type") is None:
+            continue
+
+        # Assert the expected values
         assert event.title == row.get("title")
         assert event.isin == row.get("isin")
         assert event.isin2 == row.get("isin2")

--- a/tests/zwischenpapiere2.json
+++ b/tests/zwischenpapiere2.json
@@ -1,0 +1,170 @@
+  {
+    "id": "6e123939-427f-3a4b-ba6a-ea4621ec4287",
+    "timestamp": "2026-04-03T09:37:06.806+0000",
+    "title": "WORLDLINE S.A. ANR",
+    "icon": "logos/FR0014015MS9/v2",
+    "avatar": {
+      "asset": "logos/FR0014015MS9/v2",
+      "badge": null
+    },
+    "badge": null,
+    "subtitle": "Aufruf von Zwischenpapieren",
+    "amount": {
+      "currency": "EUR",
+      "value": -1.21,
+      "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "6e123939-427f-3a4b-ba6a-ea4621ec4287"
+    },
+    "cashAccountNumber": "123456789",
+    "hidden": false,
+    "deleted": false,
+    "eventType": "SSP_CORPORATE_ACTION_CASH_AND_STOCK",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "6e123939-427f-3a4b-ba6a-ea4621ec4287",
+      "sections": [
+        {
+          "title": "Du hast 1,21 € bezahlt",
+          "data": {
+            "icon": {
+              "asset": "logos/FR0014015MS9/v2",
+              "badge": null
+            },
+            "timestamp": "2026-04-03T09:37:06.806Z",
+            "status": "executed"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Status",
+              "detail": {
+                "text": "Ausgeführt",
+                "functionalStyle": "EXECUTED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Event",
+              "detail": {
+                "text": "Aufruf von Zwischenpapieren",
+                "displayValue": {
+                  "text": "Aufruf von Zwischenpapieren"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Wertpapier",
+              "detail": {
+                "text": "WORLDLINE S.A. ANR",
+                "displayValue": {
+                  "text": "WORLDLINE S.A. ANR"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Aktien entfernt",
+              "detail": {
+                "text": "1.000000",
+                "displayValue": {
+                  "text": "1.000000"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Wertpapier",
+              "detail": {
+                "text": "Worldline",
+                "displayValue": {
+                  "text": "Worldline"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Aktien hinzugefügt",
+              "detail": {
+                "text": "6.000000",
+                "displayValue": {
+                  "text": "6.000000"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Geschäft",
+          "data": [
+            {
+              "title": "Bezugspreis",
+              "detail": {
+                "text": "-1,21 €",
+                "displayValue": {
+                  "text": "-1,21 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Steuer",
+              "detail": {
+                "text": "0,00 €",
+                "displayValue": {
+                  "text": "0,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Gesamt",
+              "detail": {
+                "text": "-1,21 €",
+                "displayValue": {
+                  "text": "-1,21 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Dokumente",
+              "detail": "03.04.2026",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "a3753865-4171-46f8-95b1-c31d2f67ac3c",
+              "postboxType": "CA_INCOME_SECURITIES_INVOICE"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/zwischenpapiere3.json
+++ b/tests/zwischenpapiere3.json
@@ -1,0 +1,159 @@
+  {
+    "id": "85b193b7-37d0-3850-8ab4-3f4a5c49efa7",
+    "timestamp": "2026-04-03T10:38:58.939+0000",
+    "title": "WORLDLINE S.A. ANR",
+    "icon": "logos/FR0014015MS9/v2",
+    "avatar": {
+      "asset": "logos/FR0014015MS9/v2",
+      "badge": null
+    },
+    "badge": null,
+    "subtitle": "Aufruf von Zwischenpapieren",
+    "amount": {
+      "currency": "EUR",
+      "value": -261.39,
+      "fractionDigits": 2
+    },
+    "subAmount": null,
+    "status": "EXECUTED",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "85b193b7-37d0-3850-8ab4-3f4a5c49efa7"
+    },
+    "cashAccountNumber": "123456789",
+    "hidden": false,
+    "deleted": false,
+    "eventType": "SSP_CORPORATE_ACTION_CASH_AND_STOCK",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "85b193b7-37d0-3850-8ab4-3f4a5c49efa7",
+      "sections": [
+        {
+          "title": "Du hast 261,39 € bezahlt",
+          "data": {
+            "icon": {
+              "asset": "logos/FR0014015MS9/v2",
+              "badge": null
+            },
+            "timestamp": "2026-04-03T10:38:58.939Z",
+            "status": "executed"
+          },
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {
+              "title": "Status",
+              "detail": {
+                "text": "Ausgeführt",
+                "functionalStyle": "EXECUTED",
+                "type": "status"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Event",
+              "detail": {
+                "text": "Aufruf von Zwischenpapieren",
+                "displayValue": {
+                  "text": "Aufruf von Zwischenpapieren"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Wertpapier",
+              "detail": {
+                "text": "WORLDLINE S.A. ANR",
+                "displayValue": {
+                  "text": "WORLDLINE S.A. ANR"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Wertpapier",
+              "detail": {
+                "text": "Worldline",
+                "displayValue": {
+                  "text": "Worldline"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Aktien hinzugefügt",
+              "detail": {
+                "text": "1294.000000",
+                "displayValue": {
+                  "text": "1294.000000"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Geschäft",
+          "data": [
+            {
+              "title": "Bezugspreis",
+              "detail": {
+                "text": "-261,39 €",
+                "displayValue": {
+                  "text": "-261,39 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Steuer",
+              "detail": {
+                "text": "0,00 €",
+                "displayValue": {
+                  "text": "0,00 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {
+              "title": "Gesamt",
+              "detail": {
+                "text": "-261,39 €",
+                "displayValue": {
+                  "text": "-261,39 €"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Dokumente",
+          "data": [
+            {
+              "title": "Dokumente",
+              "detail": "03.04.2026",
+              "action": {
+                "payload": "",
+                "type": "browserModal"
+              },
+              "id": "77ac06a1-260f-472b-ae42-83eec5ec679a",
+              "postboxType": "CA_INCOME_SECURITIES_INVOICE"
+            }
+          ],
+          "type": "documents"
+        }
+      ]
+    }
+}

--- a/tests/zwischenvertrieb2.json
+++ b/tests/zwischenvertrieb2.json
@@ -1,0 +1,83 @@
+{
+    "id": "11eb2e1f-e50c-3bb3-900d-d03028fed19d",
+    "timestamp": "2026-03-17T10:45:33.497+0000",
+    "title": "Worldline",
+    "icon": "logos/FR0011981968/v2",
+    "subtitle": "Zwischenvertrieb von Wertpapieren",
+    "action": {
+      "type": "timelineDetail",
+      "payload": "11eb2e1f-e50c-3bb3-900d-d03028fed19d"
+    },
+    "eventType": "SSP_CORPORATE_ACTION_NO_CASH",
+    "hidden": false,
+    "deleted": false,
+    "source": "timelineActivity",
+    "details": {
+      "id": "11eb2e1f-e50c-3bb3-900d-d03028fed19d",
+      "sections": [
+        {
+          "type": "header",
+          "title": "You received shares",
+          "data": {
+            "status": "executed",
+            "icon": "logos/FR0011981968/v2",
+            "timestamp": "2026-03-17T10:45:33.497510Z"
+          }
+        },
+        {
+          "type": "table",
+          "title": "Overview",
+          "data": [
+            {
+              "title": "Status",
+              "style": "plain",
+              "detail": {
+                "type": "status",
+                "text": "Completed",
+                "functionalStyle": "EXECUTED"
+              }
+            },
+            {
+              "title": "Event",
+              "style": "plain",
+              "detail": {
+                "type": "text",
+                "text": "Intermediate securities distribution"
+              }
+            },
+            {
+              "title": "Asset",
+              "style": "plain",
+              "detail": {
+                "type": "text",
+                "text": "Worldline"
+              }
+            },
+            {
+              "title": "Shares",
+              "style": "plain",
+              "detail": {
+                "type": "text",
+                "text": "1.299376"
+              }
+            }
+          ]
+        },
+        {
+          "type": "documents",
+          "title": "Documents",
+          "data": [
+            {
+              "id": "17d6cca1-9c15-4817-b865-fc119780e7ae",
+              "title": "Intermediate securities distribution",
+              "action": {
+                "type": "browserModal",
+                "payload": ""
+              },
+              "postboxType": "INTERMEDIATE_SECURITIES_DISTRIBUTION"
+            }
+          ]
+        }
+      ]
+    }
+}


### PR DESCRIPTION
Remove warnings for a few unknown events
Ignore PRIVATE_MARKET_FUND_ORDER_RECEIVED
Handle Worldline capital increase, that is ISINs involved and "Aufruf von Zwischenpapieren" without stocks removed Improve handling of bond orders
Add some code to ignore ISINs in portfolio listing. Still needs to be exposed as parameter