### PR TITLE
Taxes and Fees should always be positive numbers

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -299,8 +299,33 @@ class Event:
         note: Optional[str] = None
         subtitle = event_dict["subtitle"]
         eventdesc = f"{title} {subtitle} ({event_dict['id']})"
+        dump_dict = {"eventdesc": eventdesc, "id": event_dict["id"]}
+        pref_locale = "de"
+        (
+            fees_dict,
+            taxes_dict,
+        ) = (None,) * 2
+
         sections = event_dict.get("details", {}).get("sections", [{}])
-        uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht"], sections), None)
+
+        transaction_dict = next(filter(lambda x: x.get("title") in ["Transaktion", "Geschäft"], sections), None)
+        if transaction_dict:
+            # old style event
+            dump_dict["maintitle"] = transaction_dict["title"]
+            data = transaction_dict.get("data", [{}])
+            fees_dict = next(filter(lambda x: x["title"] == "Gebühr", data), None)
+            taxes_dict = next(filter(lambda x: x["title"] in ["Steuer", "Steuern"], data), None)
+
+        uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht", "Overview"], sections), None)
+        if uebersicht_dict:
+            # new style event
+            for item in uebersicht_dict.get("data", []):
+                ititle = item.get("title")
+                if ititle == "Gebühr" and not fees_dict:
+                    fees_dict = item
+                elif ititle == "Steuer" and not taxes_dict:
+                    taxes_dict = item
+
         event_type: Optional[EventType] = None
         eventTypeStr = event_dict.get("eventType", "")
         if eventTypeStr == "timeline_legacy_migrated_events":
@@ -444,6 +469,39 @@ class Event:
         if event_type is None:
             return cls(event_type, date, title, isin, isin2, shares, shares2, value, fees, taxes, note)
 
+        # parse fees
+        if fees_dict:
+            dump_dict["subtitle"] = fees_dict["title"]
+            dump_dict["type"] = "fees"
+            fees = cls._parse_float_from_text_value(fees_dict.get("detail", {}).get("text", ""), dump_dict)
+        elif event_type not in [
+            ConditionalEventType.SAVEBACK,
+            PPEventType.DEPOSIT,
+            PPEventType.DIVIDEND,
+            PPEventType.INTEREST,
+            PPEventType.REMOVAL,
+            PPEventType.SPINOFF,
+            PPEventType.SPLIT,
+            PPEventType.SWAP,
+            PPEventType.TAX_REFUND,
+            PPEventType.TAXES,
+        ] and subtitle not in [
+            "Aufruf von Zwischenpapieren",
+            "Wertlos",
+        ]:
+            get_event_logger().warning("Could not parse fees from %s", eventdesc)
+            get_event_logger().debug("Failed to parse fees from %s", json.dumps(event_dict, indent=4))
+
+        # parse taxes
+        if taxes_dict:
+            dump_dict["subtitle"] = taxes_dict["title"]
+            dump_dict["type"] = "taxes"
+            taxes = cls._parse_float_from_text_value(
+                taxes_dict.get("detail", {}).get("text", ""), dump_dict, pref_locale
+            )
+            if taxes and taxes < 0:
+                taxes = -taxes
+
         if isinstance(event_type, ConditionalEventType) or event_type in [
             PPEventType.DIVIDEND,
             PPEventType.SPINOFF,
@@ -452,14 +510,21 @@ class Event:
             PPEventType.TAXES,
         ]:
             isin = cls._parse_isin(event_dict)
-            shares, shares2, value, fees, taxes, note = cls._parse_shares_value_fees_taxes_note(event_type, event_dict)
+            shares, shares2, value, note = cls._parse_shares_value_note(event_type, event_dict)
         else:
             value = v if (v := event_dict.get("amount", {}).get("value", None)) is not None and v != 0.0 else None
 
-            if event_type is PPEventType.INTEREST:
-                taxes = cls._parse_taxes(event_dict)
-            elif event_type in [PPEventType.DEPOSIT, PPEventType.REMOVAL]:
+            if event_type in [PPEventType.DEPOSIT, PPEventType.REMOVAL]:
                 note = cls._parse_card_note(event_dict)
+
+        if event_type == ConditionalEventType.PRIVATE_MARKETS_ORDER:
+            if value is None:
+                shares = 0
+            else:
+                shares = abs(value) / 100
+            if fees is not None:
+                shares = shares - (abs(fees) / 100)
+            note = event_dict["subtitle"]
 
         if event_type is PPEventType.SWAP and uebersicht_dict:
             foundentfernt = False
@@ -506,32 +571,26 @@ class Event:
         return isin2 if isin2 else isin
 
     @classmethod
-    def _parse_shares_value_fees_taxes_note(
+    def _parse_shares_value_note(
         cls, event_type: Optional[EventType], event_dict: Dict[Any, Any]
     ) -> Tuple[
         Optional[float],
         Optional[float],
         Optional[float],
-        Optional[float],
-        Optional[float],
         Optional[str],
     ]:
-        """Parses the amount of shares, applicable fees and taxes
+        """Parses the amount of shares, value and note
 
         Args:
             event_dict (Dict[Any, Any]): _description_
 
         Returns:
-            Tuple[Optional[float]]: shares, fees, taxes
+            Tuple[Optional[float]]: shares, value, note
         """
         (
             shares,
             shares2,
-            fees,
-            taxes,
             note,
-            fees_dict,
-            taxes_dict,
             gesamt_dict,
             uebersicht_dict,
             shares_dict,
@@ -539,7 +598,7 @@ class Event:
             wertpapier_dict,
             wertpapier_dict2,
             quotation_dict,
-        ) = (None,) * 14
+        ) = (None,) * 10
 
         value: Optional[float] = v if (v := event_dict.get("amount", {}).get("value", None)) is not None else None
 
@@ -558,19 +617,13 @@ class Event:
             dump_dict["maintitle"] = transaction_dict["title"]
             data = transaction_dict.get("data", [{}])
             shares_dict = next(filter(lambda x: x["title"] in ["Aktien", "Anteile"], data), None)
-            fees_dict = next(filter(lambda x: x["title"] == "Gebühr", data), None)
-            taxes_dict = next(filter(lambda x: x["title"] in ["Steuer", "Steuern"], data), None)
 
         uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht", "Overview"], sections), None)
         if uebersicht_dict:
             # new style event
             for item in uebersicht_dict.get("data", []):
                 ititle = item.get("title")
-                if ititle == "Gebühr" and not fees_dict:
-                    fees_dict = item
-                elif ititle == "Steuer" and not taxes_dict:
-                    taxes_dict = item
-                elif ititle == "Gesamt":
+                if ititle == "Gesamt":
                     gesamt_dict = item
                 elif ititle in ["Wertpapier", "Asset"] and not wertpapier_dict:
                     wertpapier_dict = item
@@ -670,51 +723,6 @@ class Event:
                 value = 0
                 shares = 0
 
-        if fees_dict:
-            dump_dict["subtitle"] = fees_dict["title"]
-            dump_dict["type"] = "fees"
-            fees = cls._parse_float_from_text_value(fees_dict.get("detail", {}).get("text", ""), dump_dict)
-        elif (
-            event_type not in [PPEventType.DIVIDEND, PPEventType.SPINOFF]
-            and eventTypeStr
-            not in [
-                "ACQUISITION_TRADE_PERK",
-                "ssp_corporate_action_invoice_cash",
-                "ssp_corporate_action_invoice_shares",
-            ]
-            and title not in ["Aktien-Bonus"]
-            and subtitle
-            not in [
-                "Aktiendividende",
-                "Aktiensplit",
-                "Aufruf von Zwischenpapieren",
-                "Bonusaktien",
-                "Reverse Split",
-                "Spin-off",
-                "Teilrückzahlung ohne Reduzierung des Poolfaktors",
-                "Vorabpauschale",
-                "Wertlos",
-                "Zusammenschluss",
-            ]
-        ):
-            get_event_logger().warning("Could not parse fees from %s", eventdesc)
-            get_event_logger().debug("Failed to parse fees from %s", json.dumps(event_dict, indent=4))
-
-        if taxes_dict:
-            dump_dict["subtitle"] = taxes_dict["title"]
-            dump_dict["type"] = "taxes"
-            taxes = cls._parse_float_from_text_value(taxes_dict.get("detail", {}).get("text", ""), dump_dict)
-        # no logging here because events may or may not have taxes
-
-        if event_type == ConditionalEventType.PRIVATE_MARKETS_ORDER:
-            if value is None:
-                shares = 0
-            else:
-                shares = abs(value) / 100
-            if fees is not None:
-                shares = shares - (abs(fees) / 100)
-            note = event_dict["subtitle"]
-
         if (event_type == PPEventType.SPINOFF or subtitle == "Wertlos") and value is None:
             value = 0
 
@@ -727,54 +735,7 @@ class Event:
             elif wertpapier_dict:
                 note = wertpapier_dict["detail"]["text"]
 
-        return shares, shares2, value, fees, taxes, note
-
-    @classmethod
-    def _parse_taxes(cls, event_dict: Dict[Any, Any]) -> Optional[float]:
-        """Parses the levied taxes
-
-        Args:
-            event_dict (Dict[Any, Any]): _description_
-
-        Returns:
-            Optional[float]: taxes
-        """
-        taxes, taxes_dict = None, None
-        title = event_dict["title"]
-        subtitle = event_dict["subtitle"]
-        eventdesc = f"{title} {subtitle} ({event_dict['id']})"
-        dump_dict = {"eventdesc": eventdesc, "id": event_dict["id"]}
-        # pref_locale = "en" if event_dict.get("eventType", None) in [None, "INTEREST_PAYOUT"] else "de"
-        pref_locale = "de"
-
-        sections = event_dict.get("details", {}).get("sections", [{}])
-        transaction_dict = next(filter(lambda x: x["title"] in ["Transaktion", "Geschäft"], sections), None)
-        if transaction_dict:
-            # Filter for taxes dicts
-            dump_dict["maintitle"] = transaction_dict["title"]
-            data = transaction_dict.get("data", [{}])
-            taxes_dict = next(filter(lambda x: x["title"] in ["Steuer", "Steuern"], data), None)
-            # if transaction_dict.get("action", {}).get("type", "") == "infoPage":
-            #    pref_locale = "de"
-        else:
-            uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht"], sections), None)
-            # Iterate over the top-level data list
-            if uebersicht_dict:
-                for item in uebersicht_dict.get("data", []):
-                    if item.get("title") == "Steuer":
-                        taxes_dict = item
-                        break
-
-        # Iterate over dicts containing tax information and parse each one
-        if taxes_dict:
-            dump_dict["subtitle"] = taxes_dict["title"]
-            dump_dict["type"] = "taxes"
-            taxes = cls._parse_float_from_text_value(
-                taxes_dict.get("detail", {}).get("text", ""), dump_dict, pref_locale
-            )
-        # no logging here because events may or may not have taxes
-
-        return taxes
+        return shares, shares2, value, note
 
     @staticmethod
     def _parse_card_note(event_dict: Dict[Any, Any]) -> Optional[str]:

--- a/pytr/transactions.py
+++ b/pytr/transactions.py
@@ -131,8 +131,8 @@ class TransactionExporter:
             "note": self._translate(event.note) + " - " + event.title if event.note is not None else event.title,
             "isin": event.isin,
             "shares": self._decimal_format(event.shares, False),
-            "fees": self._decimal_format(-event.fees) if event.fees is not None else None,
-            "taxes": self._decimal_format(-event.taxes) if event.taxes is not None else None,
+            "fees": self._decimal_format(event.fees) if event.fees is not None else None,
+            "taxes": self._decimal_format(event.taxes) if event.taxes is not None else None,
             "isin2": event.isin2,
             "shares2": self._decimal_format(event.shares2, False),
         }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -154,7 +154,7 @@ def test_events():
             "title": "Enovix Corp. WTS 01.10.26",
             "isin": "US2935941318",
             "value": -0.57,
-            "taxes": -0.57,
+            "taxes": 0.57,
             "transactions": [
                 {
                     "Datum": "2026-01-06T16:14:51",
@@ -172,7 +172,7 @@ def test_events():
             "title": "Glencore",
             "isin": "JE00B4T3BW64",
             "value": 3,
-            "taxes": -1.15,
+            "taxes": 1.15,
             "transactions": [
                 {
                     "Datum": "2025-09-22T11:20:31",
@@ -190,7 +190,7 @@ def test_events():
             "title": "Glencore",
             "isin": "JE00B4T3BW64",
             "value": 3,
-            "taxes": -1.15,
+            "taxes": 1.15,
             "transactions": [
                 {
                     "Datum": "2025-09-22T11:20:31",
@@ -245,7 +245,7 @@ def test_events():
             "isin": "US20030N1019",
             "shares": 10.640298,
             "value": 2.24,
-            "taxes": -0.78,
+            "taxes": 0.78,
             "transactions": [
                 {
                     "Datum": "2025-10-23T14:19:56",
@@ -265,7 +265,7 @@ def test_events():
             "isin": "US5486611073",
             "shares": 1.189904,
             "value": 0.92,
-            "taxes": -0.32,
+            "taxes": 0.32,
             "transactions": [
                 {
                     "Datum": "2025-11-05T18:31:19",
@@ -285,7 +285,7 @@ def test_events():
             "isin": "US58463J3041",
             "shares": 40,
             "value": 4.01,
-            "taxes": -1.53,
+            "taxes": 1.53,
             "transactions": [
                 {
                     "Datum": "2025-03-20T15:04:31",
@@ -305,7 +305,7 @@ def test_events():
             "isin": "US58463J3041",
             "shares": 40,
             "value": 4.01,
-            "taxes": -1.53,
+            "taxes": 1.53,
             "transactions": [
                 {
                     "Datum": "2025-03-20T15:04:31",
@@ -396,7 +396,7 @@ def test_events():
             "title": "BYD",
             "isin": "CNE100000296",
             "value": -8.67,
-            "taxes": -8.67,
+            "taxes": 8.67,
             "transactions": [
                 {
                     "Datum": "2025-08-15T14:53:09",
@@ -414,7 +414,7 @@ def test_events():
             "title": "BYD",
             "isin": "CNE100000296",
             "value": -8.67,
-            "taxes": -8.67,
+            "taxes": 8.67,
             "transactions": [
                 {
                     "Datum": "2025-08-15T14:53:09",
@@ -442,7 +442,7 @@ def test_events():
                     "Notiz": "Juli 2040",
                     "ISIN": "DE0001135366",
                     "Stück": 82.27,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -462,7 +462,7 @@ def test_events():
                     "Notiz": "Juli 2040",
                     "ISIN": "DE0001135366",
                     "Stück": 82.27,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -482,7 +482,7 @@ def test_events():
                     "Notiz": "Euro Stoxx 50 EUR (Dist)",
                     "ISIN": "IE00B4K6B022",
                     "Stück": 60.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -502,7 +502,7 @@ def test_events():
                     "Notiz": "Euro Stoxx 50 EUR (Dist)",
                     "ISIN": "IE00B4K6B022",
                     "Stück": 60.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -522,7 +522,7 @@ def test_events():
                     "Notiz": "NVIDIA",
                     "ISIN": "US67066G1040",
                     "Stück": 0.685102,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -542,7 +542,7 @@ def test_events():
                     "Notiz": "NVIDIA",
                     "ISIN": "US67066G1040",
                     "Stück": 0.685102,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -562,7 +562,7 @@ def test_events():
                     "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
                     "ISIN": "US7731211089",
                     "Stück": 2,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -582,7 +582,7 @@ def test_events():
                     "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
                     "ISIN": "US7731211089",
                     "Stück": 2,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -660,7 +660,7 @@ def test_events():
                     "Notiz": "MSCI World USD (Dist)",
                     "ISIN": "LU0392494562",
                     "Stück": 32.0,
-                    "Steuern": -6.83,
+                    "Steuern": 6.83,
                 }
             ],
         },
@@ -670,7 +670,7 @@ def test_events():
             "title": "National Grid",
             "isin": "GB00BDR05C01",
             "value": 3.37,
-            "taxes": -1.28,
+            "taxes": 1.28,
             "transactions": [
                 {
                     "Datum": "2024-07-19T13:28:04",
@@ -688,7 +688,7 @@ def test_events():
             "title": "National Grid",
             "isin": "GB00BDR05C01",
             "value": 3.37,
-            "taxes": -1.28,
+            "taxes": 1.28,
             "transactions": [
                 {
                     "Datum": "2024-07-19T13:28:04",
@@ -830,7 +830,7 @@ def test_events():
                     "Notiz": "Marie Brizard Wine and Spirits",
                     "ISIN": "FR0000060873",
                     "Stück": 27.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -850,7 +850,7 @@ def test_events():
                     "Notiz": "Marie Brizard Wine and Spirits",
                     "ISIN": "FR0000060873",
                     "Stück": 27.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -866,7 +866,7 @@ def test_events():
                     "Typ": "Zinsen",
                     "Wert": 11.76,
                     "Notiz": "Zinsen",
-                    "Steuern": -4.51,
+                    "Steuern": 4.51,
                 }
             ],
         },
@@ -882,7 +882,7 @@ def test_events():
                     "Typ": "Zinsen",
                     "Wert": 11.76,
                     "Notiz": "Zinsen",
-                    "Steuern": -4.51,
+                    "Steuern": 4.51,
                 }
             ],
         },
@@ -903,8 +903,8 @@ def test_events():
                     "Notiz": "D-Wave Quantum",
                     "ISIN": "US26740W1099",
                     "Stück": 11.0,
-                    "Gebühren": -1.0,
-                    "Steuern": -17.36,
+                    "Gebühren": 1.0,
+                    "Steuern": 17.36,
                 }
             ],
         },
@@ -925,8 +925,8 @@ def test_events():
                     "Notiz": "Teva Pharmaceutical Industries (ADR)",
                     "ISIN": "US8816242098",
                     "Stück": 8.0,
-                    "Gebühren": -1.0,
-                    "Steuern": -7.66,
+                    "Gebühren": 1.0,
+                    "Steuern": 7.66,
                 }
             ],
         },
@@ -947,8 +947,8 @@ def test_events():
                     "Notiz": "Daimler Truck Holding",
                     "ISIN": "DE000DTR0CK8",
                     "Stück": 3.0,
-                    "Gebühren": -1.0,
-                    "Steuern": -0.14,
+                    "Gebühren": 1.0,
+                    "Steuern": 0.14,
                 }
             ],
         },
@@ -969,8 +969,8 @@ def test_events():
                     "Notiz": "Daimler Truck Holding",
                     "ISIN": "DE000DTR0CK8",
                     "Stück": 3.0,
-                    "Gebühren": -1.0,
-                    "Steuern": -0.14,
+                    "Gebühren": 1.0,
+                    "Steuern": 0.14,
                 }
             ],
         },
@@ -1063,12 +1063,14 @@ def test_events():
             "event_type": PPEventType.DEPOSIT,
             "title": "Einzahlung",
             "value": 1000,
+            "fees": 7,
             "transactions": [
                 {
                     "Datum": "2022-08-27T05:06:30",
                     "Typ": "Einlage",
                     "Wert": 1000.0,
                     "Notiz": "Einzahlung",
+                    "Gebühren": 7.0,
                 }
             ],
         },
@@ -1077,12 +1079,14 @@ def test_events():
             "event_type": PPEventType.DEPOSIT,
             "title": "Einzahlung",
             "value": 1000,
+            "fees": 7,
             "transactions": [
                 {
                     "Datum": "2022-08-27T05:06:30",
                     "Typ": "Einlage",
                     "Wert": 1000.0,
                     "Notiz": "Einzahlung",
+                    "Gebühren": 7.0,
                 }
             ],
         },
@@ -1103,7 +1107,7 @@ def test_events():
                     "Notiz": "EQT",
                     "ISIN": "LU3176111881",
                     "Stück": 1.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 },
             ],
         },
@@ -1124,7 +1128,7 @@ def test_events():
                     "Notiz": "EQT",
                     "ISIN": "LU3176111881",
                     "Stück": 1.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 },
             ],
         },
@@ -1195,7 +1199,7 @@ def test_events():
                     "Notiz": "Apollo",
                     "ISIN": "LU3170240538",
                     "Stück": 1.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 },
             ],
         },
@@ -1216,7 +1220,7 @@ def test_events():
                     "Notiz": "Apollo",
                     "ISIN": "LU3170240538",
                     "Stück": 1.0,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 },
             ],
         },
@@ -1279,7 +1283,7 @@ def test_events():
             "title": "Private Equity",
             "isin": "LU3176111881",
             "value": -0.07,
-            "taxes": -0.07,
+            "taxes": 0.07,
             "transactions": [
                 {
                     "Datum": "2026-03-09T07:56:12",
@@ -1435,8 +1439,8 @@ def test_events():
                     "Wert": 94.76,
                     "Notiz": "D-Wave Quantum",
                     "ISIN": "US26740W1099",
-                    "Gebühren": -1.0,
-                    "Steuern": -3.18,
+                    "Gebühren": 1.0,
+                    "Steuern": 3.18,
                     "Stück": 17.0,
                 }
             ],
@@ -1457,8 +1461,8 @@ def test_events():
                     "Wert": 94.76,
                     "Notiz": "D-Wave Quantum",
                     "ISIN": "US26740W1099",
-                    "Gebühren": -1.0,
-                    "Steuern": -3.18,
+                    "Gebühren": 1.0,
+                    "Steuern": 3.18,
                     "Stück": 17.0,
                 }
             ],
@@ -1509,7 +1513,7 @@ def test_events():
             "title": "Gamestop Corp. WTS 30.10.26",
             "isin": "US36467W1172",
             "value": -0.56,
-            "taxes": -0.56,
+            "taxes": 0.56,
             "transactions": [
                 {
                     "Datum": "2025-12-19T15:24:37",
@@ -1698,8 +1702,8 @@ def test_events():
                     "Notiz": "Tencent Holdings (ADR)",
                     "ISIN": "US88032Q1094",
                     "Stück": 3.454506,
-                    "Gebühren": -1.0,
-                    "Steuern": -0.16,
+                    "Gebühren": 1.0,
+                    "Steuern": 0.16,
                 }
             ],
         },
@@ -1719,7 +1723,7 @@ def test_events():
                     "Notiz": "Home Depot",
                     "ISIN": "US4370761029",
                     "Stück": 0.305182,
-                    "Gebühren": -1.0,
+                    "Gebühren": 1.0,
                 }
             ],
         },
@@ -1729,7 +1733,7 @@ def test_events():
             "title": "MSCI China USD (Acc)",
             "isin": "IE00BJ5JPG56",
             "value": -0.19,
-            "taxes": -0.19,
+            "taxes": 0.19,
             "transactions": [
                 {
                     "Datum": "2025-01-28T14:54:28",
@@ -1747,7 +1751,7 @@ def test_events():
             "title": "MSCI China USD (Acc)",
             "isin": "IE00BJ5JPG56",
             "value": -0.19,
-            "taxes": -0.19,
+            "taxes": 0.19,
             "transactions": [
                 {
                     "Datum": "2025-01-28T14:54:28",
@@ -1771,7 +1775,7 @@ def test_events():
                     "Typ": "Zinsen",
                     "Wert": 4.87,
                     "Notiz": "Zinsen",
-                    "Steuern": -1.87,
+                    "Steuern": 1.87,
                 }
             ],
         },
@@ -1787,7 +1791,7 @@ def test_events():
                     "Typ": "Zinsen",
                     "Wert": 4.87,
                     "Notiz": "Zinsen",
-                    "Steuern": -1.87,
+                    "Steuern": 1.87,
                 }
             ],
         },


### PR DESCRIPTION
There is some inconsistency with the sign of tax values. It should always be positive. Also, fees should have a positive number.

This is a breaking change, that is, modifying current behavior that might be relied on elsewhere.

With the patch we also go another step towards unification of event parsing in one method. This can help to simplify it in the end.

It addresses #317. 