### PR TITLE
fix: coerce null eventType to empty string in _parse_card_note (#350)

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -743,7 +743,11 @@ class Event:
         Returns:
             Optional[str]: note
         """
-        eventTypeStr = event_dict.get("eventType", "")
+        # `dict.get(k, default)` only returns the default when the key is
+        # absent; if the API explicitly sets eventType=None (observed on
+        # "Aktien erhalten" / shares-received events) the default is bypassed
+        # and `.startswith` then nil-derefs (#350).
+        eventTypeStr = event_dict.get("eventType") or ""
         if eventTypeStr.startswith("card_"):
             return eventTypeStr
 

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -743,10 +743,6 @@ class Event:
         Returns:
             Optional[str]: note
         """
-        # `dict.get(k, default)` only returns the default when the key is
-        # absent; if the API explicitly sets eventType=None (observed on
-        # "Aktien erhalten" / shares-received events) the default is bypassed
-        # and `.startswith` then nil-derefs (#350).
         eventTypeStr = event_dict.get("eventType") or ""
         if eventTypeStr.startswith("card_"):
             return eventTypeStr

--- a/tests/aktien_erhalten_null_eventType.json
+++ b/tests/aktien_erhalten_null_eventType.json
@@ -1,0 +1,27 @@
+{
+    "id": "9e81acd0-3fe1-409b-abfd-96f26088eeb0",
+    "timestamp": "2025-03-15T10:00:00.000+0000",
+    "title": "AI & Big Data USD (Acc)",
+    "icon": "logos/IE000716YHJ7/v2",
+    "subtitle": "Aktien erhalten",
+    "eventType": null,
+    "action": {
+        "type": "timelineDetail",
+        "payload": "9e81acd0-3fe1-409b-abfd-96f26088eeb0"
+    },
+    "source": "timelineActivity",
+    "details": {
+        "id": "9e81acd0-3fe1-409b-abfd-96f26088eeb0",
+        "sections": [
+            {
+                "title": "Du hast Aktien erhalten",
+                "data": {
+                    "icon": "logos/IE000716YHJ7/v2",
+                    "timestamp": "2025-03-15T10:00:00.000Z",
+                    "status": "executed"
+                },
+                "type": "header"
+            }
+        ]
+    }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2056,16 +2056,7 @@ def test_events():
 
 
 def test_parse_card_note_returns_none_when_event_type_is_null():
-    """Regression test for #350: an event_dict with explicit ``eventType: None``
-    (e.g. the "Aktien erhalten" / shares-received timeline entry) used to
-    crash ``_parse_card_note`` with
-    ``AttributeError: 'NoneType' object has no attribute 'startswith'``."""
-    # eventType key is explicitly null
+    """Regression for #350."""
     assert Event._parse_card_note({"eventType": None}) is None
-
-    # eventType key absent, already covered by `.get(..., "")` default but
-    # double-check we do not regress this safe path
     assert Event._parse_card_note({}) is None
-
-    # Existing happy path: card_ prefix remains recognised
     assert Event._parse_card_note({"eventType": "card_refund"}) == "card_refund"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2005,6 +2005,9 @@ def test_events():
                 }
             ],
         },
+        {
+            "filename": "aktien_erhalten_null_eventType.json",
+        },
     ]
 
     # Create an instance of EventCsvFormatter

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2053,3 +2053,19 @@ def test_events():
             entry.setdefault("ISIN2", None)
             entry.setdefault("Stück2", None)
         assert transactions == rowtransactions
+
+
+def test_parse_card_note_returns_none_when_event_type_is_null():
+    """Regression test for #350: an event_dict with explicit ``eventType: None``
+    (e.g. the "Aktien erhalten" / shares-received timeline entry) used to
+    crash ``_parse_card_note`` with
+    ``AttributeError: 'NoneType' object has no attribute 'startswith'``."""
+    # eventType key is explicitly null
+    assert Event._parse_card_note({"eventType": None}) is None
+
+    # eventType key absent — already covered by `.get(..., "")` default but
+    # double-check we do not regress this safe path
+    assert Event._parse_card_note({}) is None
+
+    # Existing happy path: card_ prefix remains recognised
+    assert Event._parse_card_note({"eventType": "card_refund"}) == "card_refund"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2063,7 +2063,7 @@ def test_parse_card_note_returns_none_when_event_type_is_null():
     # eventType key is explicitly null
     assert Event._parse_card_note({"eventType": None}) is None
 
-    # eventType key absent — already covered by `.get(..., "")` default but
+    # eventType key absent, already covered by `.get(..., "")` default but
     # double-check we do not regress this safe path
     assert Event._parse_card_note({}) is None
 


### PR DESCRIPTION
Closes #350.

`_parse_card_note` reads `event_dict.get("eventType", "")`, but `dict.get(k, default)` only returns the default when the key is **absent**. The Trade Republic timeline includes "Aktien erhalten" (shares-received) entries where the key is present with value `null`, so `eventTypeStr` becomes `None` and the next line's `eventTypeStr.startswith("card_")` nil-derefs, breaking `pytr export_transactions` CSV export end-to-end.

Replaces the default with `event_dict.get("eventType") or ""` so both missing and null collapse to an empty string. Regression test `test_parse_card_note_returns_none_when_event_type_is_null` covers the null case (the bug repro), the existing absent case, and the existing card_-prefix happy path.