### PR TITLE
fix: replace compactPortfolio with compactPortfolioByType

### DIFF
--- a/pytr/api.py
+++ b/pytr/api.py
@@ -446,7 +446,7 @@ class TradeRepublicApi:
             self.settings()
         if self._sec_acc_no is None:
             raise ValueError("Could not retrieve securities account number from account settings.")
-        return await self.subscribe({"type": "compactPortfolio", "secAccNo": self._sec_acc_no})
+        return await self.subscribe({"type": "compactPortfolioByType", "secAccNo": self._sec_acc_no})
 
     async def watchlist(self):
         return await self.subscribe({"type": "watchlist"})

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -96,9 +96,18 @@ class Portfolio:
         while recv > 0:
             subscription_id, subscription, response = await self.tr.recv()
 
-            if subscription["type"] == "compactPortfolio":
+            if subscription["type"] == "compactPortfolioByType":
                 recv -= 1
-                self.portfolio = response["positions"]
+                # New format: positions are grouped in categories[].positions
+                # Flatten all categories and normalize the field name: new API uses
+                # "isin" where the old "compactPortfolio" used "instrumentId".
+                positions = []
+                for cat in response.get("categories", []):
+                    for pos in cat.get("positions", []):
+                        if "isin" in pos and "instrumentId" not in pos:
+                            pos["instrumentId"] = pos["isin"]
+                        positions.append(pos)
+                self.portfolio = positions
             elif subscription["type"] == "cash":
                 recv -= 1
                 self.cash = response


### PR DESCRIPTION
Trade Republic changed their WebSocket API in June 2026: subscriptions to "compactPortfolio" on web sessions (connect_id=31) now return:

  BAD_SUBSCRIPTION_TYPE: Unknown topic type: compactPortfolio.31

The replacement endpoint is "compactPortfolioByType" which accepts the same optional secAccNo parameter. The response format changed: positions are now grouped in categories[].positions instead of a flat top-level positions array.

Additionally, the new format uses "isin" as the field name where the old endpoint used "instrumentId". The fix normalizes the field at reception so all downstream code in portfolio.py continues to work unchanged.

Fixes #361