### PR TITLE
Add rates command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ If you want to use the cutting-edge version, use this command instead:
 <!-- runcmd code:console uv run --python 3.13 pytr help --for-readme -->
 ```console
 usage: pytr [-h] [-V] [-v {warning,info,debug}] [--debug-logfile DEBUG_LOGFILE] [--debug-log-filter DEBUG_LOG_FILTER]
-            {help,login,portfolio,details,dl_docs,export_transactions,get_price_alarms,set_price_alarms,get_savings_plans,completion} ...
+            {help,login,portfolio,rates,details,dl_docs,export_transactions,get_price_alarms,set_price_alarms,get_savings_plans,completion} ...
 
 Use "pytr command_name --help" to get detailed help to a specific command
 
 Commands:
-  {help,login,portfolio,details,dl_docs,export_transactions,get_price_alarms,set_price_alarms,get_savings_plans,completion}
+  {help,login,portfolio,rates,details,dl_docs,export_transactions,get_price_alarms,set_price_alarms,get_savings_plans,completion}
                                         Desired action to perform
     help                                Print this help message
     login                               Check if credentials file exists. If not create it and ask for input. Try to
                                         login. Ask for device reset if needed
     portfolio                           Show current portfolio
+    rates                               Fetch current prices for a list of ISINs given as direct list or CSV input
     details                             Get details for an ISIN
     dl_docs                             Download all pdf documents from the timeline and sort them into folders. Also
                                         export account transactions (account_transactions.csv) and JSON files with all

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import re
 import shutil
 import signal
 import sys
@@ -17,6 +18,7 @@ from pytr.details import Details
 from pytr.dl import DL
 from pytr.event import Event
 from pytr.portfolio import PORTFOLIO_COLUMNS, Portfolio
+from pytr.rates import Rates, read_isins_from_csv
 from pytr.savings_plans import SavingsPlans
 from pytr.timeline import Timeline
 from pytr.transactions import SUPPORTED_LANGUAGES, TransactionExporter
@@ -155,18 +157,70 @@ def get_main_parser():
         default=False,
         help="Include watchlist.",
     )
+    parser_portfolio.add_argument(
+        "--ignore",
+        default=None,
+        metavar="ISINS",
+        help="Semicolon-separated list of ISINs to exclude from the portfolio, e.g. --ignore US30303M1027;DE0005140008",
+    )
     parser_portfolio.add_argument("-o", "--output", help="Output path of CSV file", type=Path)
     parser_portfolio.add_argument(
         "--sort-by-column",
-        type=str.lower,
-        choices=[col.lower() for col in PORTFOLIO_COLUMNS],
-        default=None,
-        help="Sort results by column.",
+        type=str,
+        choices=list(PORTFOLIO_COLUMNS),
+        default="netValue",
+        help="Sort results by column (default: netValue).",
     )
     parser_portfolio.add_argument(
         "--sort-ascending",
         action=argparse.BooleanOptionalAction,
         default=False,
+        help="Whether to sort in ascending order.",
+    )
+
+    # rates
+    info = "Fetch current prices for a list of ISINs given as direct list or CSV input"
+    parser_rates = parser_cmd.add_parser(
+        "rates",
+        formatter_class=formatter,
+        parents=[parser_login_args, parser_lang, parser_decimal_localization],
+        help=info,
+        description=info,
+    )
+    parser_rates.add_argument(
+        "input", nargs="*", help="ISINs to fetch prices for, e.g. DE0005140008 US0378331005", default=[]
+    )
+    parser_rates.add_argument(
+        "-i",
+        "--inputfile",
+        help="CSV input file containing ISINs (used when no ISINs given as positional args; default: stdin). Semicolon or comma delimited.",
+        type=argparse.FileType("r", encoding="utf-8"),
+        default="-",
+        nargs="?",
+    )
+    parser_rates.add_argument(
+        "--isin-column",
+        help='Column name in the input CSV that contains ISINs (default: auto-detect "ISIN" or first column).',
+        default=None,
+    )
+    parser_rates.add_argument(
+        "-o",
+        "--output",
+        help="Output path for CSV file (default: stdout).",
+        type=Path,
+        default=None,
+    )
+    parser_rates.add_argument(
+        "--sort-by-column",
+        type=str,
+        choices=["name", "isin", "price", "ask"],
+        default="name",
+        help="Sort results by column (default: name).",
+    )
+    parser_rates.add_argument(
+        "--sort-ascending",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Whether to sort in ascending order.",
     )
 
@@ -473,9 +527,34 @@ def main():
                 waf_token=args.waf_token,
             ),
             args.include_watchlist,
+            instruments_to_ignore=args.ignore.split(";") if args.ignore else [],
             lang=args.lang,
             decimal_localization=args.decimal_localization,
             output=args.output,
+            sort_by_column=args.sort_by_column,
+            sort_descending=not args.sort_ascending,
+        ).get()
+    elif args.command == "rates":
+        if args.input:
+            isin_re = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
+            isins = [s for s in args.input if isin_re.match(s)]
+        else:
+            isins = read_isins_from_csv(args.inputfile, args.isin_column)
+        if not isins:
+            print("No valid ISINs found in input.")
+            return -1
+        Rates(
+            login(
+                phone_no=args.phone_no,
+                pin=args.pin,
+                store_credentials=args.store_credentials,
+                waf_token=args.waf_token,
+            ),
+            isins,
+            output=args.output,
+            isin_column=args.isin_column,
+            decimal_localization=args.decimal_localization,
+            lang=args.lang,
             sort_by_column=args.sort_by_column,
             sort_descending=not args.sort_ascending,
         ).get()

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import re
 import shutil
 import signal
 import sys
@@ -17,7 +18,7 @@ from pytr.details import Details
 from pytr.dl import DL
 from pytr.event import Event
 from pytr.portfolio import PORTFOLIO_COLUMNS, Portfolio
-from pytr.rates import Rates, parse_isin_input
+from pytr.rates import RATE_COLUMNS, Rates, parse_isin_input
 from pytr.savings_plans import SavingsPlans
 from pytr.timeline import Timeline
 from pytr.transactions import SUPPORTED_LANGUAGES, TransactionExporter
@@ -160,7 +161,7 @@ def get_main_parser():
         "--ignore",
         default=None,
         metavar="ISINS",
-        help="Semicolon-separated list of ISINs to exclude from the portfolio, e.g. --ignore US30303M1027;DE0005140008",
+        help="Semicolon or comma separated list of ISINs to exclude from the portfolio, e.g. --ignore US30303M1027;DE0005140008",
     )
     parser_portfolio.add_argument("-o", "--output", help="Output path of CSV file", type=Path)
     parser_portfolio.add_argument(
@@ -195,9 +196,9 @@ def get_main_parser():
     parser_rates.add_argument(
         "-i",
         "--inputfile",
-        help="Input file containing ISINs — comma, semicolon, whitespace or newline separated. Used when no ISINs given as positional args; default: stdin.",
+        help="Input file containing ISINs — comma, semicolon, whitespace or newline separated. Used when no ISINs given as positional args. Use '-' for stdin.",
         type=argparse.FileType("r", encoding="utf-8"),
-        default="-",
+        default=None,
         nargs="?",
     )
     parser_rates.add_argument(
@@ -210,9 +211,9 @@ def get_main_parser():
     parser_rates.add_argument(
         "--sort-by-column",
         type=str,
-        choices=["name", "isin", "price", "ask"],
-        default="name",
-        help="Sort results by column (default: name).",
+        choices=list(RATE_COLUMNS),
+        default="Name",
+        help="Sort results by column (default: Name).",
     )
     parser_rates.add_argument(
         "--sort-ascending",
@@ -524,7 +525,7 @@ def main():
                 waf_token=args.waf_token,
             ),
             args.include_watchlist,
-            instruments_to_ignore=args.ignore.split(";") if args.ignore else [],
+            instruments_to_ignore=re.split(r"[,;]", args.ignore) if args.ignore else [],
             lang=args.lang,
             decimal_localization=args.decimal_localization,
             output=args.output,

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -2,7 +2,6 @@
 
 import argparse
 import asyncio
-import re
 import shutil
 import signal
 import sys
@@ -18,7 +17,7 @@ from pytr.details import Details
 from pytr.dl import DL
 from pytr.event import Event
 from pytr.portfolio import PORTFOLIO_COLUMNS, Portfolio
-from pytr.rates import Rates, read_isins_from_csv
+from pytr.rates import Rates, parse_isin_input
 from pytr.savings_plans import SavingsPlans
 from pytr.timeline import Timeline
 from pytr.transactions import SUPPORTED_LANGUAGES, TransactionExporter
@@ -188,20 +187,18 @@ def get_main_parser():
         description=info,
     )
     parser_rates.add_argument(
-        "input", nargs="*", help="ISINs to fetch prices for, e.g. DE0005140008 US0378331005", default=[]
+        "input",
+        nargs="*",
+        help="ISINs to fetch prices for; comma, semicolon or space separated, e.g. DE0005140008,US0378331005",
+        default=[],
     )
     parser_rates.add_argument(
         "-i",
         "--inputfile",
-        help="CSV input file containing ISINs (used when no ISINs given as positional args; default: stdin). Semicolon or comma delimited.",
+        help="Input file containing ISINs — comma, semicolon, whitespace or newline separated. Used when no ISINs given as positional args; default: stdin.",
         type=argparse.FileType("r", encoding="utf-8"),
         default="-",
         nargs="?",
-    )
-    parser_rates.add_argument(
-        "--isin-column",
-        help='Column name in the input CSV that contains ISINs (default: auto-detect "ISIN" or first column).',
-        default=None,
     )
     parser_rates.add_argument(
         "-o",
@@ -535,11 +532,7 @@ def main():
             sort_descending=not args.sort_ascending,
         ).get()
     elif args.command == "rates":
-        if args.input:
-            isin_re = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
-            isins = [s for s in args.input if isin_re.match(s)]
-        else:
-            isins = read_isins_from_csv(args.inputfile, args.isin_column)
+        isins = parse_isin_input(args.input, args.inputfile)
         if not isins:
             print("No valid ISINs found in input.")
             return -1
@@ -552,7 +545,6 @@ def main():
             ),
             isins,
             output=args.output,
-            isin_column=args.isin_column,
             decimal_localization=args.decimal_localization,
             lang=args.lang,
             sort_by_column=args.sort_by_column,

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -12,14 +12,14 @@ from .tickers import (
 )
 from .utils import get_logger, preview
 
-PORTFOLIO_COLUMNS = {
+PORTFOLIO_COLUMNS = [
     "Name",
     "ISIN",
     "quantity",
     "price",
     "avgCost",
     "netValue",
-}
+]
 
 
 class Portfolio:
@@ -124,11 +124,11 @@ class Portfolio:
 
     def _get_sort_func(self):
         match self.sort_by_column:
-            case "name":
+            case "Name":
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                 return lambda x: locale.strxfrm(x["name"].lower())
-            case "isin":
+            case "ISIN":
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                 return lambda x: locale.strxfrm(x["instrumentId"].lower())
@@ -161,7 +161,7 @@ class Portfolio:
 
         Path(self.output).parent.mkdir(parents=True, exist_ok=True)
         with open(self.output, "w", encoding="utf-8") as f:
-            f.write("Name;ISIN;quantity;price;avgCost;netValue\n")
+            f.write(";".join(PORTFOLIO_COLUMNS) + "\n")
             f.write("\n".join(csv_lines) + ("\n" if csv_lines else ""))
 
         print(f"Wrote {len(csv_lines) + 1} lines to {self.output}")

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -138,10 +138,9 @@ class Portfolio:
                 return lambda x: Decimal(x["price"])
             case "avgCost":
                 return lambda x: Decimal(x["averageBuyIn"])
-            case "netValue":
-                return lambda x: Decimal(x["netValue"])
             case _ as m:
-                print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
+                if m != "netValue":
+                    print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
                 return lambda x: Decimal(x["netValue"])
 
     def write_csv(self):

--- a/pytr/portfolio.py
+++ b/pytr/portfolio.py
@@ -1,29 +1,16 @@
 import asyncio
 import locale
-import re
 from decimal import ROUND_HALF_UP, Decimal
-from locale import getdefaultlocale
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
-from babel.numbers import format_decimal
-
+from .tickers import (
+    decimal_format,
+    fetch_instrument_details,
+    fetch_tickers,
+    normalize_lang,
+)
 from .utils import get_logger, preview
-
-SUPPORTED_LANGUAGES = {
-    "cs",
-    "da",
-    "de",
-    "en",
-    "es",
-    "fr",
-    "it",
-    "nl",
-    "pl",
-    "pt",
-    "ru",
-    "zh",
-}
 
 PORTFOLIO_COLUMNS = {
     "Name",
@@ -34,56 +21,37 @@ PORTFOLIO_COLUMNS = {
     "netValue",
 }
 
-bond_pattern = re.compile(
-    r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December|Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\.?\s+20\d{2}",
-    re.IGNORECASE,
-)
-
 
 class Portfolio:
     def __init__(
         self,
         tr,
-        include_watchlist=False,
-        lang="en",
-        decimal_localization=False,
+        include_watchlist: bool = False,
+        instruments_to_ignore: Optional[list[str]] = None,
         output=None,
-        sort_by_column=None,
-        sort_descending=True,
+        lang: str = "en",
+        decimal_localization: bool = False,
+        sort_by_column: Optional[str] = "netValue",
+        sort_descending: bool = True,
     ):
         self.tr = tr
         self.include_watchlist = include_watchlist
-        self.lang = lang
-        self.decimal_localization = decimal_localization
+        self.instruments_to_ignore = instruments_to_ignore or []
         self.output = output
+        self.lang = normalize_lang(lang)
+        self.decimal_localization = decimal_localization
         self.sort_by_column = sort_by_column
         self.sort_descending = sort_descending
 
-        self.watchlist = None
+        self.watchlist: list[dict] = []
 
         self._log = get_logger(__name__)
 
-        if self.lang == "auto":
-            locale = getdefaultlocale()[0]
-            if locale is None:
-                self.lang = "en"
-            else:
-                self.lang = locale.split("_")[0]
-
-        if self.lang not in SUPPORTED_LANGUAGES:
-            self._log.info(f'Language not yet supported "{self.lang}", defaulting to "en"')
-            self.lang = "en"
-
-    def _decimal_format(self, value: Optional[float], precision: int = 2) -> Union[str, None]:
-        if value is None:
-            return None
-        if self.decimal_localization:
-            format = "#,##0." + ("#" * precision)
-            return format_decimal(value, format=format, locale=self.lang)
-        else:
-            return f"{float(value):.{precision}f}".rstrip("0").rstrip(".")
+    def _decimal_format(self, value, precision: int = 2):
+        return decimal_format(value, precision, self.decimal_localization, self.lang)
 
     async def portfolio_loop(self):
+        self._log.info("Querying portfolio...")
         recv = 0
         await self.tr.compact_portfolio()
         recv += 1
@@ -101,13 +69,12 @@ class Portfolio:
                 # New format: positions are grouped in categories[].positions
                 # Flatten all categories and normalize the field name: new API uses
                 # "isin" where the old "compactPortfolio" used "instrumentId".
-                positions = []
+                self.positions = []
                 for cat in response.get("categories", []):
                     for pos in cat.get("positions", []):
                         if "isin" in pos and "instrumentId" not in pos:
                             pos["instrumentId"] = pos["isin"]
-                        positions.append(pos)
-                self.portfolio = positions
+                        self.positions.append(pos)
             elif subscription["type"] == "cash":
                 recv -= 1
                 self.cash = response
@@ -119,127 +86,70 @@ class Portfolio:
 
             await self.tr.unsubscribe(subscription_id)
 
-        # a way to ignore instruments from portfolio
-        # e.g. set to ["US30303M1027"] if you want to exclude Meta Platforms (A)
-        # this should be exposed as a parameter...
-        instruments_to_ignore = []
-
         isins = set()
-        portfolio = list()
-        for pos in self.portfolio:
-            if pos["instrumentId"] not in instruments_to_ignore:
-                portfolio.append(pos)
+        positions = list()
+        for pos in self.positions:
+            if pos["instrumentId"] not in self.instruments_to_ignore:
+                positions.append(pos)
                 isins.add(pos["instrumentId"])
-        self.portfolio = portfolio
+        self.positions = positions
 
         # extend portfolio with watchlist elements
-        if self.watchlist:
-            for pos in self.watchlist:
-                if pos["instrumentId"] not in instruments_to_ignore:
-                    isin = pos["instrumentId"]
-                    if isin not in isins:
-                        isins.add(isin)
-                        self.portfolio.append(pos)
+        for pos in self.watchlist:
+            if pos["instrumentId"] not in isins and pos["instrumentId"] not in self.instruments_to_ignore:
+                isins.add(pos["instrumentId"])
+                self.positions.append(pos)
 
-        # Populate name for each ISIN
-        subscriptions = {}
-        for pos in self.portfolio:
-            isin = pos["instrumentId"]
-            subscription_id = await self.tr.instrument_details(isin)
-            subscriptions[subscription_id] = pos
-
-        while len(subscriptions) > 0:
-            subscription_id, subscription, response = await self.tr.recv()
-
-            if subscription["type"] == "instrument":
-                await self.tr.unsubscribe(subscription_id)
-                pos = subscriptions.pop(subscription_id, None)
-                pos["name"] = response["shortName"]
-                pos["exchangeIds"] = response["exchangeIds"]
-            else:
-                print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
-
-        # Get tickers and populate netValue for each ISIN
         self._log.info("Subscribing to tickers...")
-        subscriptions = {}
-        for pos in self.portfolio:
-            isin = pos["instrumentId"]
-            if len(pos["exchangeIds"]) > 0:
-                subscription_id = await self.tr.ticker(isin, exchange=pos["exchangeIds"][0])
-                subscriptions[subscription_id] = pos
+        await fetch_instrument_details(self.tr, self.positions)
+        missing = await fetch_tickers(self.tr, self.positions)
+        for pos in missing:
+            print(
+                f"Missing price for {pos.get('name', pos['instrumentId'])} ({pos['instrumentId']}), removing from result."
+            )
 
-        self._log.info("Waiting for tickers...")
-        while len(subscriptions) > 0:
-            try:
-                subscription_id, subscription, response = await asyncio.wait_for(self.tr.recv(), 5)
-            except asyncio.TimeoutError:
-                print("Timed out waiting for tickers")
-                print(f"Remaining subscriptions: {subscriptions}")
-                break
+        self.positions = [pos for pos in self.positions if "price" in pos]
 
-            if subscription["type"] == "ticker":
-                await self.tr.unsubscribe(subscription_id)
-                pos = subscriptions.pop(subscription_id, None)
-                pos["price"] = response["last"]["price"]
-                # Bond handling
-                # Identify bonds by parsing the name - bond names are like "... month year"
-                if bond_pattern.search(pos["name"]):
-                    # Bond prices are per €100 face value
-                    pos["price"] = Decimal(pos["price"]) / 100
-
-                # watchlist positions don't have size/value
-                if "netSize" not in pos:
-                    pos["netSize"] = "0"
-                    pos["averageBuyIn"] = pos["price"]
-                pos["netValue"] = (Decimal(pos["price"]) * Decimal(pos["netSize"])).quantize(
-                    Decimal("0.01"), rounding=ROUND_HALF_UP
-                )
-            else:
-                print(f"unmatched subscription of type '{subscription['type']}':\n{preview(response)}")
-
-        # sanitize - it can happen that we get no price, e.g. we ran into a timeout above or some instrument
-        # does not deliver a price. Then we kick it out of the list and log this.
-        portfolionew = []
-        for pos in self.portfolio:
-            if "price" not in pos:
-                print(f"Missing price for {pos['name']} ({pos['instrumentId']}), removing from result.")
-            else:
-                portfolionew.append(pos)
-        self.portfolio = portfolionew
+        # Compute netValue from price and netSize (netSize comes from the portfolio, not tickers)
+        for pos in self.positions:
+            # watchlist positions don't have size/value
+            if "netSize" not in pos:
+                pos["netSize"] = "0"
+                pos["averageBuyIn"] = pos["price"]
+            pos["netValue"] = (Decimal(pos["price"]) * Decimal(pos["netSize"])).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
 
         await self.tr.close()
 
     def _get_sort_func(self):
-        if self.sort_by_column:
-            match self.sort_by_column.lower():
-                case "name":
-                    if self.lang == "de":
-                        locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
-                    return lambda x: locale.strxfrm(x["name"].lower())
-                case "isin":
-                    if self.lang == "de":
-                        locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
-                    return lambda x: locale.strxfrm(x["instrumentId"].lower())
-                case "quantity":
-                    return lambda x: Decimal(x["netSize"])
-                case "price":
-                    return lambda x: Decimal(x["price"])
-                case "avgCost":
-                    return lambda x: Decimal(x["averageBuyIn"])
-                case "netValue":
-                    return lambda x: Decimal(x["netValue"])
-                case _ as m:
-                    print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
-                    return lambda x: Decimal(x["netValue"])
-        else:
-            return lambda x: Decimal(x["netValue"])
+        match self.sort_by_column:
+            case "name":
+                if self.lang == "de":
+                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                return lambda x: locale.strxfrm(x["name"].lower())
+            case "isin":
+                if self.lang == "de":
+                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                return lambda x: locale.strxfrm(x["instrumentId"].lower())
+            case "quantity":
+                return lambda x: Decimal(x["netSize"])
+            case "price":
+                return lambda x: Decimal(x["price"])
+            case "avgCost":
+                return lambda x: Decimal(x["averageBuyIn"])
+            case "netValue":
+                return lambda x: Decimal(x["netValue"])
+            case _ as m:
+                print(f"Column {m} does not exist for portfolio list, reverting to default sorting by netValue.")
+                return lambda x: Decimal(x["netValue"])
 
-    def portfolio_to_csv(self):
+    def write_csv(self):
         if self.output is None:
             return
 
         csv_lines = []
-        for pos in sorted(self.portfolio, key=self._get_sort_func(), reverse=self.sort_descending):
+        for pos in sorted(self.positions, key=self._get_sort_func(), reverse=self.sort_descending):
             csv_lines.append(
                 f"{pos['name']};"
                 f"{pos['instrumentId']};"
@@ -265,7 +175,7 @@ class Portfolio:
                 "Name                      ISIN            avgCost *   quantity =    buyCost ->   netValue      price       diff   %-diff"
             )
 
-        for pos in sorted(self.portfolio, key=self._get_sort_func(), reverse=self.sort_descending):
+        for pos in sorted(self.positions, key=self._get_sort_func(), reverse=self.sort_descending):
             buyCost = (Decimal(pos["averageBuyIn"]) * Decimal(pos["netSize"])).quantize(
                 Decimal("0.01"), rounding=ROUND_HALF_UP
             )
@@ -304,4 +214,4 @@ class Portfolio:
         asyncio.run(self.portfolio_loop())
 
         self.overview()
-        self.portfolio_to_csv()
+        self.write_csv()

--- a/pytr/rates.py
+++ b/pytr/rates.py
@@ -1,5 +1,4 @@
 import asyncio
-import csv
 import locale
 import re
 from decimal import Decimal
@@ -21,7 +20,6 @@ class Rates:
         tr,
         isins: list[str],
         output=None,
-        isin_column: Optional[str] = None,
         lang: str = "en",
         decimal_localization: bool = False,
         sort_by_column: Optional[str] = "name",
@@ -30,7 +28,6 @@ class Rates:
         self.tr = tr
         self.isins = isins
         self.output = output
-        self.isin_column = isin_column
         self.lang = normalize_lang(lang)
         self.decimal_localization = decimal_localization
         self.sort_by_column = sort_by_column
@@ -108,32 +105,32 @@ class Rates:
             self.write_csv()
 
 
-def read_isins_from_csv(fileobj, isin_column: Optional[str]) -> list[str]:
-    """Read ISINs from a CSV file (semicolon or comma delimited).
+ISIN_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
 
-    If isin_column is given, use that column header; otherwise try 'ISIN', then fall back
-    to the first column that looks like ISINs (12-char alphanumeric starting with two letters).
+
+def _extract_isins(tokens: list[str]) -> list[str]:
+    return [t for t in tokens if ISIN_RE.match(t)]
+
+
+def _split_isin_text(text: str) -> list[str]:
+    """Split text on commas, semicolons, or whitespace and return non-empty tokens."""
+    return [t.strip() for t in re.split(r"[,;\s]+", text) if t.strip()]
+
+
+def parse_isin_input(input_list: list[str], fileobj) -> list[str]:
+    """Return ISINs from input_list (preferred) or from a file/stdin.
+
+    Tokens may be comma, semicolon, or whitespace/newline separated.
     """
-    content = fileobj.read()
-    delimiter = ";" if content.count(";") >= content.count(",") else ","
-    reader = csv.DictReader(content.splitlines(), delimiter=delimiter)
+    if input_list:
+        tokens = _split_isin_text(" ".join(input_list))
+        return _extract_isins(tokens)
 
-    if reader.fieldnames is None:
+    if fileobj is None:
         return []
 
-    col = isin_column
-    if col is None:
-        for candidate in ["ISIN", "isin"]:
-            if candidate in reader.fieldnames:
-                col = candidate
-                break
-        if col is None:
-            col = reader.fieldnames[0]
+    content = fileobj.read()
+    if not content.strip():
+        return []
 
-    isins = []
-    isin_re = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
-    for row in reader:
-        value = row.get(col, "").strip()
-        if isin_re.match(value):
-            isins.append(value)
-    return isins
+    return _extract_isins(_split_isin_text(content))

--- a/pytr/rates.py
+++ b/pytr/rates.py
@@ -13,6 +13,13 @@ from .tickers import (
 )
 from .utils import get_logger
 
+RATE_COLUMNS = [
+    "Name",
+    "ISIN",
+    "price",
+    "ask",
+]
+
 
 class Rates:
     def __init__(
@@ -59,11 +66,11 @@ class Rates:
 
     def _get_sort_func(self):
         match self.sort_by_column:
-            case "name":
+            case "Name":
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                 return lambda x: locale.strxfrm(x["name"].lower())
-            case "isin":
+            case "ISIN":
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                 return lambda x: locale.strxfrm(x["instrumentId"].lower())
@@ -72,8 +79,10 @@ class Rates:
             case "price":
                 return lambda x: Decimal(x["price"])
             case _ as m:
-                print(f"Column {m} does not exist for portfolio list, reverting to default sorting by price.")
-                return lambda x: Decimal(x["price"])
+                print(f"Column {m} does not exist for rates list, reverting to default sorting by Name.")
+                if self.lang == "de":
+                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                return lambda x: locale.strxfrm(x["name"].lower())
 
     def overview(self):
         print(f"{'Name':<30.30} {'ISIN':<12}  {'price':>10}  {'ask':>10}")
@@ -90,7 +99,7 @@ class Rates:
             f"{p['name']};{p['instrumentId']};{self._decimal_format(p['price'])};{self._decimal_format(p.get('ask'))}"
             for p in sorted(self.positions, key=self._get_sort_func(), reverse=self.sort_descending)
         ]
-        header = "name;ISIN;price;ask"
+        header = ";".join(RATE_COLUMNS)
         content = header + "\n" + "\n".join(lines) + ("\n" if lines else "")
         Path(self.output).parent.mkdir(parents=True, exist_ok=True)
         with open(self.output, "w", encoding="utf-8") as f:

--- a/pytr/rates.py
+++ b/pytr/rates.py
@@ -66,10 +66,6 @@ class Rates:
 
     def _get_sort_func(self):
         match self.sort_by_column:
-            case "Name":
-                if self.lang == "de":
-                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
-                return lambda x: locale.strxfrm(x["name"].lower())
             case "ISIN":
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
@@ -79,7 +75,8 @@ class Rates:
             case "price":
                 return lambda x: Decimal(x["price"])
             case _ as m:
-                print(f"Column {m} does not exist for rates list, reverting to default sorting by Name.")
+                if m != "Name":
+                    print(f"Column {m} does not exist for rates list, reverting to default sorting by Name.")
                 if self.lang == "de":
                     locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
                 return lambda x: locale.strxfrm(x["name"].lower())

--- a/pytr/rates.py
+++ b/pytr/rates.py
@@ -1,0 +1,139 @@
+import asyncio
+import csv
+import locale
+import re
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+from .tickers import (
+    decimal_format,
+    fetch_instrument_details,
+    fetch_tickers,
+    normalize_lang,
+)
+from .utils import get_logger
+
+
+class Rates:
+    def __init__(
+        self,
+        tr,
+        isins: list[str],
+        output=None,
+        isin_column: Optional[str] = None,
+        lang: str = "en",
+        decimal_localization: bool = False,
+        sort_by_column: Optional[str] = "name",
+        sort_descending: bool = False,
+    ):
+        self.tr = tr
+        self.isins = isins
+        self.output = output
+        self.isin_column = isin_column
+        self.lang = normalize_lang(lang)
+        self.decimal_localization = decimal_localization
+        self.sort_by_column = sort_by_column
+        self.sort_descending = sort_descending
+
+        self._log = get_logger(__name__)
+
+    def _decimal_format(self, value, precision: int = 4):
+        return decimal_format(value, precision, self.decimal_localization, self.lang)
+
+    async def rates_loop(self):
+        if not self.isins:
+            self._log.warning("No ISINs provided.")
+            return
+
+        self.positions = [{"instrumentId": isin} for isin in self.isins]
+
+        self._log.info("Subscribing to tickers...")
+        await fetch_instrument_details(self.tr, self.positions)
+        missing = await fetch_tickers(self.tr, self.positions)
+        for pos in missing:
+            self._log.warning(
+                f"Missing price for {pos.get('name', pos['instrumentId'])} ({pos['instrumentId']}), removing from result."
+            )
+
+        self.positions = [pos for pos in self.positions if "price" in pos]
+
+        await self.tr.close()
+
+    def _get_sort_func(self):
+        match self.sort_by_column:
+            case "name":
+                if self.lang == "de":
+                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                return lambda x: locale.strxfrm(x["name"].lower())
+            case "isin":
+                if self.lang == "de":
+                    locale.setlocale(locale.LC_COLLATE, "de_DE.UTF-8")
+                return lambda x: locale.strxfrm(x["instrumentId"].lower())
+            case "ask":
+                return lambda x: Decimal(x["ask"]) if x.get("ask") is not None else Decimal(0)
+            case "price":
+                return lambda x: Decimal(x["price"])
+            case _ as m:
+                print(f"Column {m} does not exist for portfolio list, reverting to default sorting by price.")
+                return lambda x: Decimal(x["price"])
+
+    def overview(self):
+        print(f"{'Name':<30.30} {'ISIN':<12}  {'price':>10}  {'ask':>10}")
+        for p in sorted(self.positions, key=self._get_sort_func(), reverse=self.sort_descending):
+            print(
+                f"{p['name']:<30.30} "
+                f"{p['instrumentId']:<12}  "
+                f"{self._decimal_format(p['price']):>10}  "
+                f"{self._decimal_format(p.get('ask')):>10}"
+            )
+
+    def write_csv(self):
+        lines = [
+            f"{p['name']};{p['instrumentId']};{self._decimal_format(p['price'])};{self._decimal_format(p.get('ask'))}"
+            for p in sorted(self.positions, key=self._get_sort_func(), reverse=self.sort_descending)
+        ]
+        header = "name;ISIN;price;ask"
+        content = header + "\n" + "\n".join(lines) + ("\n" if lines else "")
+        Path(self.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(self.output, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"Wrote {len(lines) + 1} lines to {self.output}")
+
+    def get(self):
+        asyncio.run(self.rates_loop())
+        if self.output is None:
+            self.overview()
+        else:
+            self.write_csv()
+
+
+def read_isins_from_csv(fileobj, isin_column: Optional[str]) -> list[str]:
+    """Read ISINs from a CSV file (semicolon or comma delimited).
+
+    If isin_column is given, use that column header; otherwise try 'ISIN', then fall back
+    to the first column that looks like ISINs (12-char alphanumeric starting with two letters).
+    """
+    content = fileobj.read()
+    delimiter = ";" if content.count(";") >= content.count(",") else ","
+    reader = csv.DictReader(content.splitlines(), delimiter=delimiter)
+
+    if reader.fieldnames is None:
+        return []
+
+    col = isin_column
+    if col is None:
+        for candidate in ["ISIN", "isin"]:
+            if candidate in reader.fieldnames:
+                col = candidate
+                break
+        if col is None:
+            col = reader.fieldnames[0]
+
+    isins = []
+    isin_re = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
+    for row in reader:
+        value = row.get(col, "").strip()
+        if isin_re.match(value):
+            isins.append(value)
+    return isins

--- a/pytr/tickers.py
+++ b/pytr/tickers.py
@@ -1,0 +1,109 @@
+import asyncio
+import re
+from decimal import Decimal
+from locale import getdefaultlocale
+from typing import Optional
+
+from babel.numbers import format_decimal
+
+from .utils import get_logger
+
+SUPPORTED_LANGUAGES = {
+    "cs",
+    "da",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "nl",
+    "pl",
+    "pt",
+    "ru",
+    "zh",
+}
+
+bond_pattern = re.compile(
+    r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December|Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\.?\s+20\d{2}",
+    re.IGNORECASE,
+)
+
+_log = get_logger(__name__)
+
+
+def normalize_lang(lang: str) -> str:
+    """Resolve 'auto' to the system locale language, fall back to 'en' if unsupported."""
+    if lang == "auto":
+        detected = getdefaultlocale()[0]
+        lang = detected.split("_")[0] if detected else "en"
+    if lang not in SUPPORTED_LANGUAGES:
+        _log.info(f'Language not yet supported "{lang}", defaulting to "en"')
+        lang = "en"
+    return lang
+
+
+def decimal_format(
+    value,
+    precision: int = 2,
+    decimal_localization: bool = False,
+    lang: str = "en",
+) -> Optional[str]:
+    if value is None:
+        return None
+    if decimal_localization:
+        fmt = "#,##0." + ("#" * precision)
+        return format_decimal(value, format=fmt, locale=lang)
+    return f"{float(value):.{precision}f}".rstrip("0").rstrip(".")
+
+
+async def fetch_instrument_details(tr, positions: list[dict]) -> None:
+    """Populate pos['name'] and pos['exchangeIds'] for each position in-place."""
+    subscriptions = {}
+    for pos in positions:
+        sub_id = await tr.instrument_details(pos["instrumentId"])
+        subscriptions[sub_id] = pos
+
+    while subscriptions:
+        sub_id, subscription, response = await tr.recv()
+        if subscription["type"] == "instrument":
+            await tr.unsubscribe(sub_id)
+            pos = subscriptions.pop(sub_id)
+            pos["name"] = response.get("shortName", pos["instrumentId"])
+            pos["exchangeIds"] = response.get("exchangeIds", [])
+        else:
+            _log.debug(f"Unexpected subscription type: {subscription['type']}")
+
+
+async def fetch_tickers(tr, positions: list[dict], timeout: float = 5.0) -> list[dict]:
+    """Fetch ticker prices for positions that have exchangeIds.
+
+    Populates pos['price'] and pos['ask'] in-place. Bond prices are divided by 100.
+    Returns the list of positions for which no price was received.
+    """
+    subscriptions = {}
+    for pos in positions:
+        if pos.get("exchangeIds"):
+            sub_id = await tr.ticker(pos["instrumentId"], exchange=pos["exchangeIds"][0])
+            subscriptions[sub_id] = pos
+        else:
+            _log.warning(f"No exchange found for {pos['instrumentId']}, skipping.")
+
+    while subscriptions:
+        try:
+            sub_id, subscription, response = await asyncio.wait_for(tr.recv(), timeout)
+        except asyncio.TimeoutError:
+            _log.warning(f"Timed out waiting for tickers: {list(subscriptions.values())}")
+            break
+
+        if subscription["type"] == "ticker":
+            await tr.unsubscribe(sub_id)
+            pos = subscriptions.pop(sub_id)
+            pos["price"] = response["last"]["price"]
+            if bond_pattern.search(pos.get("name", "")):
+                pos["price"] = Decimal(pos["price"]) / 100
+            pos["ask"] = response.get("ask", {}).get("price")
+        else:
+            _log.debug(f"Unexpected subscription type: {subscription['type']}")
+
+    missing = [pos for pos in positions if "price" not in pos]
+    return missing


### PR DESCRIPTION
## Summary

This PR introduces a new `rates` command that fetches current bid/ask prices for a list of ISINs from Trade Republic.

- ISINs can be passed as positional arguments (`pytr rates DE0005140008 US0378331005`), read from an input file (`-i`), or piped via stdin (`-i -`)
- Without `-o`, output is a fixed-column table sorted by name; with `-o`, a semicolon-delimited CSV is written
- Supports the same `--lang`, `--decimal-localization`, `--sort-by-column`, and `--sort-ascending` options as the portfolio command

To avoid duplicating the WebSocket subscription logic, a new `tickers.py` module has been extracted with shared helpers used by both `portfolio` and `rates`:
- `fetch_instrument_details()` — fetches name and exchange IDs for a list of positions
- `fetch_tickers()` — fetches bid/ask prices with bond price correction (÷100)
- `normalize_lang()`, `decimal_format()` — shared formatting utilities

The portfolio command also gains a new `--ignore` flag accepting a semicolon-separated list of ISINs to exclude from the output.