### PR TITLE
Fix crash in _parse_card_note when eventType is null

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -765,7 +765,7 @@ class Event:
             Optional[str]: note
         """
         eventTypeStr = event_dict.get("eventType", "")
-        if eventTypeStr.startswith("card_"):
+        if eventTypeStr is not None and eventTypeStr.startswith("card_"):
             return eventTypeStr
 
         sections = event_dict.get("details", {}).get("sections", [{}])

--- a/tests/kartenzahlung_null_eventType.json
+++ b/tests/kartenzahlung_null_eventType.json
@@ -1,0 +1,103 @@
+{
+  "id": "39a1ecdf-0c09-5e5f-8e31-ba666f1eefe6",
+  "timestamp": "2025-10-21T17:30:01.281+0000",
+  "title": "Coop Pronto",
+  "icon": "logos/merchant-fallback-groceries/v2",
+  "avatar": {
+    "asset": "logos/merchant-fallback-groceries/v2",
+    "badge": null
+  },
+  "badge": null,
+  "subtitle": null,
+  "amount": {
+    "currency": "EUR",
+    "value": -12.16,
+    "fractionDigits": 2
+  },
+  "subAmount": {
+    "currency": "CHF",
+    "value": -11.2,
+    "fractionDigits": 2
+  },
+  "status": "EXECUTED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "39a1ecdf-0c09-5e5f-8e31-ba666f1eefe6"
+  },
+  "eventType": null,
+  "cashAccountNumber": null,
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineTransaction",
+  "details": {
+    "id": "39a1ecdf-0c09-5e5f-8e31-ba666f1eefe6",
+    "sections": [
+      {
+        "title": "Du hast 12,16 € ausgegeben",
+        "data": {
+          "icon": "logos/merchant-fallback-groceries/v2",
+          "timestamp": "2025-10-21T17:30:01.281Z",
+          "status": "executed"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Kartenzahlung",
+            "detail": {
+              "text": "Fertig",
+              "functionalStyle": "EXECUTED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Zahlung",
+            "detail": {
+              "text": "··5891",
+              "icon": "logos/bank_traderepublic/v2",
+              "type": "iconWithText"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Händler",
+            "detail": {
+              "text": "Coop Pronto",
+              "displayValue": {
+                "text": "Coop Pronto"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Betrag",
+            "detail": {
+              "text": "11,20 CHF",
+              "displayValue": {
+                "text": "11,20 CHF"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Gesamt",
+            "detail": {
+              "text": "12,16 €",
+              "displayValue": {
+                "text": "12,16 €"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      }
+    ]
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -820,6 +820,21 @@ def test_events():
             ],
         },
         {
+            "filename": "kartenzahlung_null_eventType.json",
+            "event_type": PPEventType.REMOVAL,
+            "title": "Coop Pronto",
+            "value": -12.16,
+            "note": "card_successful_transaction",
+            "transactions": [
+                {
+                    "Datum": "2025-10-21T17:30:01",
+                    "Typ": "Entnahme",
+                    "Wert": -12.16,
+                    "Notiz": "Kartentransaktion - Coop Pronto",
+                }
+            ],
+        },
+        {
             "filename": "kartenzahlung_no_eventType.json",
             "event_type": PPEventType.REMOVAL,
             "title": "Baecker",


### PR DESCRIPTION
event_dict.get("eventType", "") only falls back to "" when the key is missing, not when it is present but null, which Trade Republic sends for some card events. That None then hits .startswith("card_") and raises AttributeError: 'NoneType' object has no attribute 'startswith'.

Added a regression fixture with eventType explicitly null (the existing kartenzahlung_no_eventType.json only covers the key being absent, a different case)