### PR TITLE
export_transactions: add --load-event-database to skip TR login

### DIFF
--- a/pytr/main.py
+++ b/pytr/main.py
@@ -368,6 +368,13 @@ def get_main_parser():
         action=argparse.BooleanOptionalAction,
     )
     parser_export_transactions.add_argument(
+        "--load-event-database",
+        help="Load events from this all_events.json file instead of fetching from TR (implies no login)",
+        metavar="PATH",
+        type=Path,
+        default=None,
+    )
+    parser_export_transactions.add_argument(
         "--export-format",
         "--format",
         choices=("json", "csv"),
@@ -592,7 +599,9 @@ def main():
             return -1
 
         tl = Timeline(
-            login(
+            None
+            if not_before == -1 or args.load_event_database is not None
+            else login(
                 phone_no=args.phone_no,
                 pin=args.pin,
                 store_credentials=args.store_credentials,
@@ -604,6 +613,7 @@ def main():
             args.store_event_database,
             args.scan_for_duplicates,
             args.dump_raw_data,
+            load_event_database=args.load_event_database,
         )
         asyncio.run(tl.tl_loop())
         events = tl.events

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -43,15 +43,17 @@ class Timeline:
         scan_for_duplicates=False,
         dump_raw_data=False,
         event_callback=lambda *a, **kw: None,
+        load_event_database=None,
     ):
         self.tr = tr
         self.output_path = output_path
-        if not_before == -1:
+        if load_event_database is not None or not_before == -1:
             self.fetch_from_tr = False
             self.not_before = float(0)
         else:
             self.fetch_from_tr = True
             self.not_before = not_before
+        self.load_event_database = load_event_database
         self.not_after = not_after
         self.store_event_database = store_event_database
         self.scan_for_duplicates = scan_for_duplicates
@@ -74,11 +76,12 @@ class Timeline:
         output_path.mkdir(parents=True, exist_ok=True)
 
     async def tl_loop(self):
-        await self.get_next_timeline_transactions(None)
-
-        # We might not want to download anything from TR but just create/update account_transactions.csv from available data
         if not self.fetch_from_tr:
+            # We might not want to download anything from TR but just create/update account_transactions.csv from available data
             self.finish_timeline_details()
+            return
+
+        await self.get_next_timeline_transactions(None)
 
         while not self.dl_done:
             try:
@@ -281,16 +284,25 @@ class Timeline:
         else:
             self.log.info("Skip fetching data from TR.")
 
-        if self.store_event_database:
-            self.log.info("Updating event database...")
-
-            # read old events from all_events.json
+        if self.store_event_database or self.load_event_database is not None:
+            # read old events from all_events.json (or explicit --load-event-database path)
             old_events = []
-            all_events_path = self.output_path / "all_events.json"
+            all_events_path = (
+                self.load_event_database
+                if self.load_event_database is not None
+                else self.output_path / "all_events.json"
+            )
             if all_events_path.exists():
-                self.log.info("Reading event database...")
+                self.log.info(f"Loading event database from {all_events_path}...")
                 with open(all_events_path, "r", encoding="utf-8") as f:
-                    old_events = json.load(f)
+                    try:
+                        old_events = json.load(f)
+                    except json.JSONDecodeError:
+                        self.log.warning(f"Event database file is empty or invalid: {all_events_path}")
+                if not old_events:
+                    self.log.warning("No events found in event database.")
+            elif self.load_event_database is not None:
+                self.log.warning(f"Event database file not found: {all_events_path}")
 
             # if we have new data from a certain period, throw out old data
             if self.fetch_from_tr and (self.not_before != 0 or self.not_after != float("inf")):
@@ -353,11 +365,10 @@ class Timeline:
             self.log.info("Sorting events...")
             self.events.sort(key=lambda value: datetime.fromisoformat(value["timestamp"][:19]))
 
-            if self.fetch_from_tr:
+            if self.fetch_from_tr and self.store_event_database:
                 self.log.info(f"Writing {all_events_path}...")
                 with open(all_events_path, "w", encoding="utf-8") as f:
                     json.dump(self.events, f, ensure_ascii=False, indent=2, default=str)
-
-            self.log.info("Updated event database.")
+                self.log.info("Updated event database.")
 
         self.dl_done = True

--- a/tests/all_events_test.json
+++ b/tests/all_events_test.json
@@ -1,0 +1,195 @@
+[
+  {
+    "id": "12345678",
+    "timestamp": "2024-02-20T16:32:07.731+0000",
+    "title": "Euro Stoxx 50 EUR (Dist)",
+    "icon": "logos/IE00B4K6B022/v2",
+    "badge": null,
+    "subtitle": "Kauforder",
+    "amount": {"currency": "EUR", "value": -3002.8, "fractionDigits": 2},
+    "status": "EXECUTED",
+    "action": {"type": "timelineDetail", "payload": "12345678"},
+    "eventType": "ORDER_EXECUTED",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "12345678",
+      "sections": [
+        {
+          "title": "Du hast 3.002,80 € investiert",
+          "data": {"icon": "logos/IE00B4K6B022/v2", "status": "executed"},
+          "action": {"type": "instrumentDetail", "payload": "IE00B4K6B022"},
+          "type": "header"
+        },
+        {
+          "title": "Transaktion",
+          "data": [
+            {"title": "Anteile", "detail": {"text": "60", "type": "text"}, "style": "plain"},
+            {"title": "Aktienkurs", "detail": {"text": "50,03 €", "type": "text"}, "style": "plain"},
+            {"title": "Gebühr", "detail": {"text": "1,00 €", "type": "text"}, "style": "plain"},
+            {"title": "Gesamt", "detail": {"text": "3.002,80 €", "type": "text"}, "style": "highlighted"}
+          ],
+          "type": "table"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5b0f491f-7bad-40b1-8cd1-56d83729afd4",
+    "timestamp": "2025-03-14T07:03:14.000+0000",
+    "title": "D-Wave Quantum",
+    "icon": "logos/US26740W1099/v2",
+    "subtitle": "Stop-Sell-Order",
+    "amount": {"currency": "EUR", "value": 94.76, "fractionDigits": 2},
+    "status": "EXECUTED",
+    "action": {"type": "timelineDetail", "payload": "5b0f491f-7bad-40b1-8cd1-56d83729afd4"},
+    "eventType": "trading_trade_executed",
+    "cashAccountNumber": "123456789",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "5b0f491f-7bad-40b1-8cd1-56d83729afd4",
+      "sections": [
+        {
+          "title": "Du hast 94,76 € erhalten",
+          "data": {"icon": "logos/US26740W1099/v2", "status": "executed"},
+          "action": {"payload": "US26740W1099", "type": "instrumentDetail"},
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {"title": "Asset", "detail": {"text": "D-Wave Quantum", "type": "text"}, "style": "plain"},
+            {
+              "title": "Transaktion",
+              "detail": {
+                "text": "17 × 5,82 €",
+                "action": {
+                  "payload": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "sections": [
+                      {"title": "Transaktion", "type": "title"},
+                      {
+                        "data": [
+                          {"title": "Aktien", "detail": {"text": "17", "type": "text"}, "style": "plain"},
+                          {"title": "Aktienkurs", "detail": {"text": "5,82 €", "type": "text"}, "style": "plain"},
+                          {"title": "Summe", "detail": {"text": "98,94 €", "type": "text"}, "style": "plain"}
+                        ],
+                        "type": "table"
+                      }
+                    ]
+                  },
+                  "type": "infoPage"
+                },
+                "type": "text"
+              },
+              "style": "plain"
+            },
+            {"title": "Steuer", "detail": {"text": "3,18 €", "type": "text"}, "style": "plain"},
+            {"title": "Gebühr", "detail": {"text": "1,00 €", "type": "text"}, "style": "plain"},
+            {"title": "Summe", "detail": {"text": "94,76 €", "type": "text"}, "style": "plain"}
+          ],
+          "type": "table"
+        }
+      ]
+    }
+  },
+  {
+    "id": "88008da6-da94-3e0e-8ea5-e3878643f5ab",
+    "timestamp": "2025-10-23T14:19:56.295+0000",
+    "title": "Comcast (A)",
+    "icon": "logos/US20030N1019/v2",
+    "subtitle": "Bardividende",
+    "amount": {"currency": "EUR", "value": 2.24, "fractionDigits": 2},
+    "status": "EXECUTED",
+    "action": {"type": "timelineDetail", "payload": "88008da6-da94-3e0e-8ea5-e3878643f5ab"},
+    "eventType": "ssp_corporate_action_invoice_cash",
+    "cashAccountNumber": "123456789",
+    "source": "timelineTransaction",
+    "details": {
+      "id": "88008da6-da94-3e0e-8ea5-e3878643f5ab",
+      "sections": [
+        {
+          "title": "Du hast 2,24 € erhalten",
+          "data": {"icon": "logos/US20030N1019/v2", "status": "executed"},
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {"title": "Event", "detail": {"text": "Bardividende", "type": "text"}, "style": "plain"},
+            {"title": "Wertpapier", "detail": {"text": "Comcast (A)", "type": "text"}, "style": "plain"}
+          ],
+          "type": "table"
+        },
+        {
+          "title": "Geschäft",
+          "data": [
+            {"title": "Aktien", "detail": {"text": "10.640298", "type": "text"}, "style": "plain"},
+            {"title": "Steuer", "detail": {"text": "-0,78 €", "type": "text"}, "style": "plain"},
+            {"title": "Gesamt", "detail": {"text": "2,24 €", "type": "text"}, "style": "plain"}
+          ],
+          "type": "table"
+        }
+      ]
+    }
+  },
+  {
+    "id": "deposit-001",
+    "timestamp": "2024-06-03T17:07:26.374+0000",
+    "title": "My Name",
+    "icon": "logos/timeline_plus_circle/v2",
+    "subtitle": null,
+    "amount": {"currency": "EUR", "value": 200.0, "fractionDigits": 2},
+    "status": "EXECUTED",
+    "action": {"type": "timelineDetail", "payload": "deposit-001"},
+    "eventType": "timeline_legacy_migrated_events",
+    "cashAccountNumber": null,
+    "source": "timelineTransaction",
+    "details": {
+      "id": "deposit-001",
+      "sections": [
+        {
+          "title": "Du hast 200,00 € erhalten",
+          "data": {"icon": "logos/timeline_plus_circle/v2", "status": "executed"},
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {"title": "Von", "detail": {"text": "My Name", "type": "text"}, "style": "plain"},
+            {"title": "IBAN", "detail": {"text": "...", "type": "text"}, "style": "plain"}
+          ],
+          "type": "table"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e230be28-286a-31b6-879f-5c97f8a9d85a",
+    "timestamp": "2024-06-26T08:06:40.347+0000",
+    "title": "Chipotle Mexican Grill",
+    "icon": "logos/US1696561059/v2",
+    "subtitle": "Aktiensplit",
+    "action": {"type": "timelineDetail", "payload": "e230be28-286a-31b6-879f-5c97f8a9d85a"},
+    "eventType": "ssp_corporate_action_invoice_shares",
+    "source": "timelineActivity",
+    "details": {
+      "id": "e230be28-286a-31b6-879f-5c97f8a9d85a",
+      "sections": [
+        {
+          "title": "Du hast Aktien aus einer Kapitalmaßnahme erhalten",
+          "data": {"icon": "logos/US1696561059/v2", "status": "executed"},
+          "type": "header"
+        },
+        {
+          "title": "Übersicht",
+          "data": [
+            {"title": "Orderart", "detail": {"text": "Aktiensplit", "type": "text"}, "style": "plain"},
+            {"title": "Wertpapier", "detail": {"text": "Chipotle", "type": "text"}, "style": "plain"},
+            {"title": "Aktien hinzugefügt", "detail": {"text": "49.000000", "type": "text"}, "style": "plain"}
+          ],
+          "type": "table"
+        }
+      ]
+    }
+  }
+]

--- a/tests/all_events_test_golden.csv
+++ b/tests/all_events_test_golden.csv
@@ -1,0 +1,6 @@
+Datum;Typ;Wert;Notiz;ISIN;Stück;Gebühren;Steuern;ISIN2;Stück2
+2024-02-20T16:32:07;Kauf;-3.002,8;Euro Stoxx 50 EUR (Dist);IE00B4K6B022;60;1;;;
+2024-06-03T17:07:26;Einlage;200;My Name;;;;;;
+2024-06-26T08:06:40;Split;0;Chipotle Mexican Grill;US1696561059;49;;;;
+2025-03-14T07:03:14;Verkauf;94,76;D-Wave Quantum;US26740W1099;17;1;3,18;;
+2025-10-23T14:19:56;Dividende;2,24;Comcast (A);US20030N1019;10,640298;;0,78;;

--- a/tests/test_export_transactions.py
+++ b/tests/test_export_transactions.py
@@ -1,0 +1,166 @@
+"""
+Tests for export_transactions via --load-event-database (no TR login or connection).
+Uses tests/all_events_test.json with 5 events: buy, sell, dividend, deposit, split.
+"""
+
+import asyncio
+import csv
+import io
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from pytr.event import Event
+from pytr.timeline import Timeline
+from pytr.transactions import TransactionExporter
+
+ALL_EVENTS_FILE = Path(__file__).parent / "all_events_test.json"
+GOLDEN_CSV = Path(__file__).parent / "all_events_test_golden.csv"
+
+
+def load_events(output_dir):
+    tl = Timeline(
+        tr=None,
+        output_path=output_dir,
+        store_event_database=False,
+        load_event_database=ALL_EVENTS_FILE,
+    )
+    asyncio.run(tl.tl_loop())
+    return tl.events
+
+
+def export_csv(events):
+    parsed = [Event.from_dict(e) for e in events]
+    buf = io.StringIO()
+    TransactionExporter(lang="de").export(buf, parsed, sort=True, format="csv")
+    buf.seek(0)
+    return list(csv.DictReader(buf, delimiter=";"))
+
+
+def test_no_tr_connection(tmp_path, monkeypatch):
+    """Timeline must not touch self.tr at all when load_event_database is set."""
+    import pytr.timeline as tl_module
+
+    original_init = tl_module.Timeline.__init__
+    connection_attempted = []
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+
+        class NoConnection:
+            def __getattr__(self, name):
+                connection_attempted.append(name)
+                raise AssertionError(f"TR connection attempted: tr.{name}()")
+
+        self.tr = NoConnection()
+
+    monkeypatch.setattr(tl_module.Timeline, "__init__", patched_init)
+
+    tl = tl_module.Timeline(
+        tr=None,
+        output_path=tmp_path,
+        store_event_database=False,
+        load_event_database=ALL_EVENTS_FILE,
+    )
+    asyncio.run(tl.tl_loop())
+
+    assert not connection_attempted, f"TR was contacted via: {connection_attempted}"
+
+
+def test_all_events_loaded(tmp_path):
+    """All 5 events from the file are loaded into tl.events."""
+    events = load_events(tmp_path)
+    assert len(events) == 5
+
+
+def test_events_sorted_by_timestamp(tmp_path):
+    """Events are returned in chronological order."""
+    events = load_events(tmp_path)
+    timestamps = [datetime.fromisoformat(e["timestamp"][:19]) for e in events]
+    assert timestamps == sorted(timestamps)
+
+
+def test_no_database_written(tmp_path):
+    """No all_events.json is written to output_dir when loading from an external file."""
+    load_events(tmp_path)
+    assert not (tmp_path / "all_events.json").exists()
+
+
+def test_csv_row_count(tmp_path):
+    """CSV contains at least one row per event."""
+    rows = export_csv(load_events(tmp_path))
+    assert len(rows) >= 5
+
+
+def test_csv_transaction_types(tmp_path):
+    """CSV contains the expected transaction types for all 5 event kinds."""
+    rows = export_csv(load_events(tmp_path))
+    types = {r["Typ"] for r in rows}
+    assert "Kauf" in types
+    assert "Verkauf" in types
+    assert "Dividende" in types
+    assert "Einlage" in types
+
+
+def test_csv_buy_row(tmp_path):
+    """BUY row has correct ISIN, shares, value and fees."""
+    rows = export_csv(load_events(tmp_path))
+    buy = next(r for r in rows if r["Typ"] == "Kauf")
+    assert buy["ISIN"] == "IE00B4K6B022"
+    assert float(buy["Stück"].replace(",", ".")) == 60.0
+    assert float(buy["Wert"].replace(",", ".")) == -3002.8
+    assert float(buy["Gebühren"].replace(",", ".")) == 1.0
+
+
+def test_csv_sell_row(tmp_path):
+    """SELL row has correct ISIN, shares, value, fees and taxes."""
+    rows = export_csv(load_events(tmp_path))
+    sell = next(r for r in rows if r["Typ"] == "Verkauf")
+    assert sell["ISIN"] == "US26740W1099"
+    assert float(sell["Stück"].replace(",", ".")) == 17.0
+    assert float(sell["Wert"].replace(",", ".")) == 94.76
+    assert float(sell["Gebühren"].replace(",", ".")) == 1.0
+    assert float(sell["Steuern"].replace(",", ".")) == 3.18
+
+
+def test_csv_dividend_row(tmp_path):
+    """DIVIDEND row has correct ISIN, shares, value and taxes."""
+    rows = export_csv(load_events(tmp_path))
+    div = next(r for r in rows if r["Typ"] == "Dividende")
+    assert div["ISIN"] == "US20030N1019"
+    assert float(div["Wert"].replace(",", ".")) == 2.24
+    assert float(div["Steuern"].replace(",", ".")) == 0.78
+
+
+def test_csv_deposit_row(tmp_path):
+    """DEPOSIT row has correct value."""
+    rows = export_csv(load_events(tmp_path))
+    deposit = next(r for r in rows if r["Typ"] == "Einlage")
+    assert float(deposit["Wert"].replace(",", ".")) == 200.0
+
+
+def test_cli_golden(tmp_path):
+    """CLI output matches the golden CSV exactly."""
+    out_file = tmp_path / "account_transactions.csv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytr",
+            "export_transactions",
+            "--load-event-database",
+            str(ALL_EVENTS_FILE),
+            "-l",
+            "de",
+            "--decimal-localization",
+            "-s",
+            str(out_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"pytr exited with {result.returncode}:\n{result.stderr}"
+    actual = out_file.read_text(encoding="utf-8")
+    expected = GOLDEN_CSV.read_text(encoding="utf-8")
+    assert actual == expected


### PR DESCRIPTION
Add a --load-event-database PATH option to export_transactions that loads events from an arbitrary all_events.json instead of fetching from Trade Republic, skipping authentication entirely. --last_days -1 also benefits from the same fix: both paths now avoid calling login() and no longer touch self.tr in Timeline.tl_loop().

Improvements to Timeline:
- tl_loop() returns early when fetch_from_tr is false, preventing any accidental access to self.tr
- Event database is only written back when data was actually fetched (fetch_from_tr and store_event_database both true)
- Log messages distinguish "Loading event database from <path>" (read-only) from "Updated event database." (after a live fetch and write)
- Empty or invalid JSON in the event database file logs a warning instead of crashing with JSONDecodeError

Add tests/all_events_test.json (5 events: buy, sell, dividend, deposit, split), a golden CSV, and tests/test_export_transactions.py with 11 tests covering no-connection guarantee, event loading, chronological sort, no spurious database write, per-type CSV assertions, and a CLI golden-file test.