### PR TITLE
Add parsing for SSP_SECURITIES_TRANSFER_INCOMING and more ignored events

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -75,6 +75,8 @@ tr_event_type_mapping = {
     "OUTGOING_TRANSFER": PPEventType.REMOVAL,
     "OUTGOING_TRANSFER_DELEGATION": PPEventType.REMOVAL,
     "PAYMENT_OUTBOUND": PPEventType.REMOVAL,
+    # Transfers
+    "SSP_SECURITIES_TRANSFER_INCOMING": PPEventType.TRANSFER_IN,
     # Saveback
     "ACQUISITION_TRADE_PERK": ConditionalEventType.SAVEBACK,
     "BENEFITS_SAVEBACK_EXECUTION": ConditionalEventType.SAVEBACK,
@@ -173,6 +175,7 @@ subtitle_event_type_mapping = {
 }
 
 events_known_ignored = [
+    "ADDRESS_CHANGED",
     "AML_SOURCE_OF_WEALTH_RESPONSE_EXECUTED",
     "CARD_FAILED_VERIFICATION",
     "CARD_SUCCESSFUL_VERIFICATION",
@@ -262,6 +265,7 @@ events_known_ignored_subtitle = [
     "Jährliche Hauptversammlung",
     "Kartenprüfung",
     "Kauf-Abrechnung storniert",
+    "Kauforder abgelehnt",
     "Kauforder storniert",
     "Limit-Buy-Order abgelaufen",
     "Limit-Buy-Order erstellt",
@@ -383,7 +387,7 @@ class Event:
             dump_dict["maintitle"] = transaction_dict["title"]
             data = transaction_dict.get("data", [{}])
             shares_dict = next(filter(lambda x: x["title"] in ["Aktien", "Anteile", "Shares"], data), None)
-            fees_dict = next(filter(lambda x: x["title"] == "Gebühr", data), None)
+            fees_dict = next(filter(lambda x: x["title"] in ["Gebühr", "Fee"], data), None)
             taxes_dict = next(filter(lambda x: x["title"] in ["Steuer", "Steuern"], data), None)
 
         uebersicht_dict = next(
@@ -668,7 +672,7 @@ class Event:
         if (event_type == PPEventType.SPINOFF or subtitle == "Wertlos") and value is None:
             value = 0
 
-        if event_type in [PPEventType.SPLIT, PPEventType.SWAP] and value is None:
+        if event_type in [PPEventType.SPLIT, PPEventType.SWAP, PPEventType.TRANSFER_IN] and value is None:
             value = 0
 
         if event_type in [PPEventType.SPINOFF, PPEventType.SWAP]:

--- a/tests/events/address_changed.json
+++ b/tests/events/address_changed.json
@@ -1,0 +1,12 @@
+{
+  "id": "059ce705-3c54-4019-b008-79946d835a37",
+  "timestamp": "2024-09-13T14:58:01.873+0000",
+  "title": "Adresse",
+  "icon": "logos/timeline_flag/v2",
+  "subtitle": "Geändert",
+  "action": null,
+  "eventType": "ADDRESS_CHANGED",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity"
+}

--- a/tests/events/kauforder_abgelehnt.json
+++ b/tests/events/kauforder_abgelehnt.json
@@ -1,0 +1,99 @@
+{
+  "id": "7385dbae-c8c4-4e59-bc40-da708a074e96",
+  "timestamp": "2026-03-03T11:35:17.995+0000",
+  "title": "Silver 3x Lev USD (Acc)",
+  "icon": "logos/IE00B7XD2195/v2",
+  "subtitle": "Kauforder abgelehnt",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "7385dbae-c8c4-4e59-bc40-da708a074e96"
+  },
+  "eventType": "TRADING_ORDER_REJECTED",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "7385dbae-c8c4-4e59-bc40-da708a074e96",
+    "sections": [
+      {
+        "title": "Deine Kauforder wurde abgelehnt",
+        "data": {
+          "icon": "logos/IE00B7XD2195/v2",
+          "timestamp": "2026-03-03T11:34:47.966Z",
+          "status": "executed"
+        },
+        "action": {
+          "payload": "IE00B7XD2195",
+          "type": "instrumentDetail"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Kauf",
+            "detail": {
+              "text": "Abgelehnt",
+              "functionalStyle": "CANCELED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Asset",
+            "detail": {
+              "text": "Silver 3x Lev USD (Acc)",
+              "displayValue": {
+                "text": "Silver 3x Lev USD (Acc)"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Transaktion",
+            "detail": {
+              "text": "0,505689 ×  --",
+              "action": {
+                "payload": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "sections": [
+                    {
+                      "title": "Transaktion",
+                      "type": "title"
+                    },
+                    {
+                      "data": [
+                        {
+                          "title": "Aktien",
+                          "detail": {
+                            "text": "0,505689",
+                            "displayValue": {
+                              "text": "0,505689"
+                            },
+                            "type": "text"
+                          },
+                          "style": "plain"
+                        }
+                      ],
+                      "type": "table"
+                    }
+                  ]
+                },
+                "type": "infoPage"
+              },
+              "displayValue": {
+                "text": "--",
+                "prefix": "0,505689 × "
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      }
+    ]
+  }
+}

--- a/tests/events/neues_geraet.json
+++ b/tests/events/neues_geraet.json
@@ -1,0 +1,12 @@
+{
+  "id": "5f054afa-2eb5-409b-805d-6d3d9d45ffad",
+  "timestamp": "2026-02-18T17:45:01.178+0000",
+  "title": "Neues Gerät",
+  "icon": "logos/timeline_computers/v2",
+  "subtitle": null,
+  "action": null,
+  "eventType": null,
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity"
+}

--- a/tests/events/securities_transfer_incoming.json
+++ b/tests/events/securities_transfer_incoming.json
@@ -1,0 +1,83 @@
+{
+  "id": "756ce232-a67d-4d85-a431-57483426450a",
+  "timestamp": "2025-10-13T12:43:03.988+0000",
+  "title": "MSCI EM USD (Acc)",
+  "icon": "logos/IE00BTJRMP35/v2",
+  "subtitle": "Aktien erhalten",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "756ce232-a67d-4d85-a431-57483426450a"
+  },
+  "cashAccountNumber": "123456789",
+  "eventType": "SSP_SECURITIES_TRANSFER_INCOMING",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "756ce232-a67d-4d85-a431-57483426450a",
+    "sections": [
+      {
+        "type": "header",
+        "title": "You received 7 shares",
+        "data": {
+          "status": "executed",
+          "icon": "logos/IE00BTJRMP35/v2",
+          "timestamp": "2025-10-13T12:43:03.988647Z"
+        }
+      },
+      {
+        "type": "table",
+        "title": "Overview",
+        "data": [
+          {
+            "title": "Status",
+            "style": "plain",
+            "detail": {
+              "type": "status",
+              "text": "Completed",
+              "functionalStyle": "EXECUTED"
+            }
+          },
+          {
+            "title": "Asset",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "MSCI EM USD (Acc)"
+            }
+          },
+          {
+            "title": "Action",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Securities transfer"
+            }
+          }
+        ]
+      },
+      {
+        "type": "table",
+        "title": "Transaction",
+        "data": [
+          {
+            "title": "Shares",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "7"
+            }
+          },
+          {
+            "title": "Fee",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Free"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,6 +7,10 @@ from pytr.transactions import TransactionExporter
 def test_events():
     test_data = [
         {
+            "filename": "address_changed.json",
+            "event_type": None,
+        },
+        {
             "filename": "aktien_entfernt.json",
             "event_type": ConditionalEventType.TRADE_INVOICE,
             "title": "ORSTED A/S   -ANR-",
@@ -897,6 +901,10 @@ def test_events():
             ],
         },
         {
+            "filename": "kauforder_abgelehnt.json",
+            "event_type": None,
+        },
+        {
             "filename": "legacy_verkauforder_neu_abgerechnet.json",
             "event_type": ConditionalEventType.TRADE_INVOICE,
             "title": "Marie Brizard Wine and Spirits",
@@ -1055,6 +1063,10 @@ def test_events():
                     "Steuern": 0.14,
                 }
             ],
+        },
+        {
+            "filename": "neues_geraet.json",
+            "event_type": None,
         },
         {
             "filename": "outgoing_transfer.json",
@@ -1691,6 +1703,24 @@ def test_events():
                     "Notiz": "TSMC (ADR)",
                     "ISIN": "US8740391003",
                     "Stück": 0.037523,
+                }
+            ],
+        },
+        {
+            "filename": "securities_transfer_incoming.json",
+            "event_type": PPEventType.TRANSFER_IN,
+            "title": "MSCI EM USD (Acc)",
+            "isin": "IE00BTJRMP35",
+            "shares": 7,
+            "value": 0,
+            "transactions": [
+                {
+                    "Datum": "2025-10-13T12:43:03",
+                    "Typ": "Umbuchung (Eingang)",
+                    "Wert": 0,
+                    "Notiz": "MSCI EM USD (Acc)",
+                    "ISIN": "IE00BTJRMP35",
+                    "Stück": 7.0,
                 }
             ],
         },


### PR DESCRIPTION
## Summary

- Maps `SSP_SECURITIES_TRANSFER_INCOMING` to `TRANSFER_IN`, including ISIN parsing, share count, and value defaulting to 0
- Adds `ADDRESS_CHANGED` to `events_known_ignored`
- Adds `"Kauforder abgelehnt"` to `events_known_ignored_subtitle`
- Adds `"Fee"` to the fees_dict lookup for English-language event sections
- Adds `TRANSFER_IN` to the value=0 default guard
- Adds test fixtures and test rows for all four new cases

This PR picks up the work from #359 by @shukali and closes #358. The fixtures and the approach are taken directly from that PR; the code was adapted to fit the current state of the branch (which has since diverged due to other refactoring work).

Co-authored-by: Marcus Rottschäfer <shukali@users.noreply.github.com>

## Test plan

- [ ] `uv run pytest` passes (13 tests)
- [ ] `securities_transfer_incoming.json` parses as `TRANSFER_IN` with correct ISIN, shares=7, value=0
- [ ] `address_changed.json`, `kauforder_abgelehnt.json`, `neues_geraet.json` all parse as `event_type=None` (silently ignored)