### PR TITLE
Fix crash on document deeplink payload without path

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -284,10 +284,16 @@ class DL:
                 self.log.warning(f"no subfolder mapping for {eventdesc}")
 
             for idx, doc in enumerate(section["data"]):
-                if isinstance(doc["action"]["payload"], dict):
-                    self.log.warning(
-                        f'Download of document with new API-Path URL "{doc["action"]["payload"]["path"]}" is not possible. (yet?)'
-                    )
+                payload = doc["action"]["payload"]
+                if isinstance(payload, dict):
+                    if "path" in payload:
+                        self.log.warning(
+                            f'Download of document with new API-Path URL "{payload["path"]}" is not possible. (yet?)'
+                        )
+                    else:
+                        self.log.warning(
+                            f'Download of document with unsupported action payload "{payload}" is not possible. (yet?)'
+                        )
                     continue
                 has_docs = True
                 timestamp_str = event["timestamp"]

--- a/tests/test_dl.py
+++ b/tests/test_dl.py
@@ -1,0 +1,106 @@
+"""Tests for pytr.dl.DL.dl_callback document download handling."""
+
+from pytr.dl import DL
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warnings = []
+        self.debugs = []
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def debug(self, msg):
+        self.debugs.append(msg)
+
+
+def make_event(payload):
+    """Minimal timeline detail event with a single document, based on a real-world sample."""
+    return {
+        "id": "0598f7a7-cabe-454b-a520-3579999d49e8",
+        "title": "Portfolioauszug Q2 2026",
+        "subtitle": None,
+        "timestamp": "2026-07-29T13:06:13+02:00",
+        "details": {
+            "sections": [
+                {
+                    "title": "Portfolioauszug Q2 2026",
+                    "data": {
+                        "icon": {"asset": "logos/timeline_document/v2", "badge": None},
+                        "subtitleText": "29 Juli · 13:06",
+                        "status": "executed",
+                    },
+                    "type": "header",
+                },
+                {
+                    "title": "Dokumente",
+                    "data": [
+                        {
+                            "title": "Portfolioauszug",
+                            "action": {"payload": payload, "type": "deeplink"},
+                            "id": "3069857f-7eb4-3c12-a821-ac5f01dbe882",
+                            "postboxType": "",
+                        }
+                    ],
+                    "type": "documents",
+                },
+            ]
+        },
+    }
+
+
+def make_dl():
+    dl = DL.__new__(DL)
+    dl.log = FakeLogger()
+    dl.events_with_docs = []
+    dl.events_without_docs = []
+    dl.filepaths = []
+    dl.doc_urls = []
+    dl.doc_urls_history = []
+    return dl
+
+
+def test_deeplink_payload_without_path_does_not_crash():
+    """A dict payload without a 'path' key (e.g. an app deeplink) must not raise KeyError."""
+    dl = make_dl()
+    event = make_event({"link": "traderepublic://update-app-dialog"})
+
+    dl.dl_callback(event)
+
+    assert any("unsupported action payload" in w for w in dl.log.warnings)
+    assert "traderepublic://update-app-dialog" in " ".join(dl.log.warnings)
+    assert event in dl.events_without_docs
+    assert dl.events_with_docs == []
+
+
+def test_api_path_payload_logs_new_api_path_warning():
+    """A dict payload containing a 'path' key keeps the existing 'new API-Path' warning."""
+    dl = make_dl()
+    event = make_event({"path": "/api/v1/portfolio-statements/12345"})
+
+    dl.dl_callback(event)
+
+    assert any("new API-Path URL" in w for w in dl.log.warnings)
+    assert any("/api/v1/portfolio-statements/12345" in w for w in dl.log.warnings)
+    assert event in dl.events_without_docs
+    assert dl.events_with_docs == []
+
+
+def test_string_payload_queues_document(tmp_path):
+    """A plain string payload is a download URL and queues the document for download."""
+    dl = make_dl()
+    dl.flat = False
+    dl.output_path = tmp_path
+    dl.filename_fmt = "{iso_date} - {title} - {subtitle} - {doc_num} - {id}"
+    dl.universal_filepath = False
+    doc_url = "/api/v1/documents/12345?type=portfolio"
+    dl.doc_urls_history = [doc_url.split("?")[0]]
+
+    event = make_event(doc_url)
+    dl.dl_callback(event)
+
+    assert event in dl.events_with_docs
+    assert dl.events_without_docs == []
+    assert dl.filepaths == [event["details"]["sections"][1]["data"][0]["local_filepath"]]
+    assert any("already in history" in d for d in dl.log.debugs)


### PR DESCRIPTION
Some timeline detail documents carry an action payload with a 'link' deeplink (e.g. traderepublic://update-app-dialog) instead of a 'path', which raised `KeyError` during dl_callback. Check for 'path' before logging and warn generically for unsupported dict payloads.

Add tests covering deeplink, API-path and plain string payloads.

```
2026-08-01 16:52:21+0200 api       DEBUG    Received message: '551 A {\n  "id" : "0598f7a7-cabe-454b-a520-3579999d49e8",\n  "sections" : [ {\n    "title" : "Portfolioauszug Q2 2026",\n    "data" : {\n      "icon" : {\n        "asset" : "logos/timeline_document/v2",\n        "badge" : null\n      },\n      "subtitleText" : "29 Juli · 13:06",\n      "status" : "executed"\n    },\n    "type" : "header"\n  }, {\n    "banners" : [ {\n      "title" : "Vierteljährlicher Portfolioauszug",\n      "description" : "Dein vierteljährlicher Portfolioauszug steht zum Herunterladen bereit."\n    } ],\n    "type" : "bannerStack"\n  }, {\n    "title" : "Dokumente",\n    "data" : [ {\n      "title" : "Portfolioauszug",\n      "action" : {\n        "payload" : {\n          "link" : "traderepublic://update-app-dialog"\n        },\n        "type" : "deeplink"\n      },\n      "id" : "xxxxxxx-xxxx-xxxx-xxxx-xxxxx",\n      "postboxType" : ""\n    } ],\n    "type" : "documents"\n  } ]\n}'
2026-08-01 16:52:21+0200 timeline  INFO     569/578: Portfolioauszug Q2 2026 -- None - 2026-07-29T13:06:13
2026-08-01 16:52:21+0200 dl        WARNING  no subfolder mapping for Portfolioauszug Q2 2026 None (0598f7a7-cabe-454b-a520-3579999d49e8)
Traceback (most recent call last):
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/bin/pytr", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/lib/python3.14/site-packages/pytr/main.py", line 499, in main
    ).do_dl()
      ~~~~~^^
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/lib/python3.14/site-packages/pytr/dl.py", line 217, in do_dl
    asyncio.run(self.tl.tl_loop())
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/miry/.local/share/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/asyncio/runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/Users/miry/.local/share/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/miry/.local/share/uv/python/cpython-3.14.0-macos-aarch64-none/lib/python3.14/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/lib/python3.14/site-packages/pytr/timeline.py", line 108, in tl_loop
    await self.process_timelineDetail(response, subscription.get("id"))
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/lib/python3.14/site-packages/pytr/timeline.py", line 265, in process_timelineDetail
    self.event_callback(event)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/miry/.cache/uv/archive-v0/AogmhjcZ0PggOaHq/lib/python3.14/site-packages/pytr/dl.py", line 289, in dl_callback
    f'Download of document with new API-Path URL "{doc["action"]["payload"]["path"]}" is not possible. (yet?)'
                                                   ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'path' 
```