### PR TITLE
Overhaul dl_docs

### DIFF
--- a/pytr/dl.py
+++ b/pytr/dl.py
@@ -17,19 +17,33 @@ from .utils import get_logger
 event_subfolder_mapping = {
     "OUTGOING_TRANSFER_DELEGATION": "Auszahlungen",
     "OUTGOING_TRANSFER": "Auszahlungen",
+    "BANK_TRANSACTION_OUTGOING": "Auszahlungen",
     "CREDIT": "Dividende",
-    "ssp_corporate_action_invoice_cash": "Dividende",
+    "SSP_CORPORATE_ACTION_INVOICE_CASH": "Dividende",
+    "SSP_CORPORATE_ACTION_CASH": "Dividende",
+    "SSP_CORPORATE_ACTION_CASH_AND_STOCK": "Dividende",
     "ACCOUNT_TRANSFER_INCOMING": "Einzahlungen",
     "INCOMING_TRANSFER_DELEGATION": "Einzahlungen",
     "INCOMING_TRANSFER": "Einzahlungen",
     "PAYMENT_INBOUND_GOOGLE_PAY": "Einzahlungen",
     "PAYMENT_INBOUND_SEPA_DIRECT_DEBIT": "Einzahlungen",
+    "BANK_TRANSACTION_INCOMING": "Einzahlungen",
+    "PAYMENT_INBOUND": "Einzahlungen",
+    "JUNIOR_P2P_TRANSFER": "Einzahlungen",
+    "CARD_TRANSACTION": "Karte",
+    "CARD_REFUND": "Karte",
+    "CARD_VERIFICATION": "Karte",
     "CREDIT_CANCELED": "Misc",
     "CRYPTO_ANNUAL_STATEMENT": "Misc",
+    "CRYPTO_TNC_UPDATE_2025": "Misc",
+    "CSX_CHAT_ACTIVITY": "Misc",
     "CUSTOMER_CREATED": "Misc",
+    "DEVICE_RESET": "Misc",
     "DOCUMENTS_ACCEPTED": "Misc",
     "DOCUMENTS_CHANGED": "Misc",
     "DOCUMENTS_CREATED": "Misc",
+    "EMAIL_VALIDATED": "Misc",
+    "EXEMPTION_ORDER_CHANGED": "Misc",
     "EX_POST_COST_REPORT": "Misc",
     "EX_POST_COST_REPORT_CREATED": "Misc",
     "GENERAL_MEETING": "Misc",
@@ -38,45 +52,59 @@ event_subfolder_mapping = {
     "INSTRUCTION_CORPORATE_ACTION": "Misc",
     "JUNIOR_ONBOARDING_GUARDIAN_B_CONSENT": "Misc",
     "PRE_DETERMINED_TAX_BASE_EARNING": "Misc",
+    "PRIVATE_MARKETS_SUITABILITY_QUIZ_COMPLETED": "Misc",
+    "PUK_CREATED": "Misc",
+    "QUARTERLY_NET_WORTH_STATEMENT_CREATED": "Misc",
     "QUARTERLY_REPORT": "Misc",
+    "REFERENCE_ACCOUNT_CHANGED": "Misc",
+    "SECURITIES_ACCOUNT_CREATED": "Misc",
     "SHAREBOOKING": "Misc",
     "SHAREBOOKING_TRANSACTIONAL": "Misc",
+    "SPARE_CHANGE_AGGREGATE": "RoundUp",
+    "SSP_CAPITAL_INCREASE_CUSTOMER_INSTRUCTION": "Misc",
+    "SSP_CORPORATE_ACTION_ACTIVITY": "Misc",
+    "SSP_CORPORATE_ACTION_CASH_NON_DIVIDEND": "Misc",
+    "SSP_CORPORATE_ACTION_INFORMATIVE": "Misc",
+    "SSP_CORPORATE_ACTION_INFORMATIVE_NOTIFICATION": "Misc",
+    "SSP_CORPORATE_ACTION_INSTRUCTION": "Misc",
+    "SSP_CORPORATE_ACTION_INVOICE_SHARES": "Misc",
+    "SSP_CORPORATE_ACTION_NO_CASH": "Misc",
+    "SSP_CORPORATE_ACTION_UPCOMING": "Misc",
+    "SSP_DIVIDEND_OPTION_CUSTOMER_INSTRUCTION": "Misc",
+    "SSP_GENERAL_MEETING_CUSTOMER_INSTRUCTION": "Misc",
+    "SSP_TENDER_OFFER_CUSTOMER_INSTRUCTION": "Misc",
     "STOCK_PERK_REFUNDED": "Misc",
     "TAX_YEAR_END_REPORT": "Misc",
     "TAX_YEAR_END_REPORT_CREATED": "Misc",
+    "VERIFICATION_TRANSFER_ACCEPTED": "Misc",
     "YEAR_END_TAX_REPORT": "Misc",
-    "crypto_annual_statement": "Misc",
-    "private_markets_suitability_quiz_completed": "Misc",
-    "ssp_capital_increase_customer_instruction": "Misc",
-    "ssp_corporate_action_informative_notification": "Misc",
-    "ssp_corporate_action_invoice_shares": "Misc",
-    "ssp_dividend_option_customer_instruction": "Misc",
-    "ssp_general_meeting_customer_instruction": "Misc",
-    "ssp_tender_offer_customer_instruction": "Misc",
-    "benefits_spare_change_execution": "RoundUp",
-    "benefits_saveback_execution": "Saveback",
+    "BENEFITS_SPARE_CHANGE_EXECUTION": "RoundUp",
+    "BENEFITS_SAVEBACK_EXECUTION": "Saveback",
+    "SAVEBACK_AGGREGATE": "Saveback",
     "SAVINGS_PLAN_EXECUTED": "Sparplan",
     "SAVINGS_PLAN_INVOICE_CREATED": "Sparplan",
-    "trading_savingsplan_executed": "Sparplan",
-    "trading_savingsplan_execution_failed": "Sparplan",
+    "TRADING_SAVINGSPLAN_EXECUTED": "Sparplan",
+    "TRADING_SAVINGSPLAN_EXECUTION_FAILED": "Sparplan",
+    "SSP_TAX_CORRECTION": "Steuerkorrekturen",
+    "SSP_TAX_CORRECTION_INVOICE": "Steuerkorrekturen",
     "TAX_CORRECTION": "Steuerkorrekturen",
     "TAX_REFUND": "Steuerkorrekturen",
-    "ssp_tax_correction_invoice": "Steuerkorrekturen",
+    "IPO_TRADE_EXECUTED": "Trades",
     "ORDER_CANCELED": "Trades",
     "ORDER_EXECUTED": "Trades",
     "ORDER_EXPIRED": "Trades",
     "ORDER_REJECTED": "Trades",
+    "PRIVATE_MARKET_FUND_TRADE_EXECUTED": "Trades",
+    "PRIVATE_MARKETS_TRADE_EXECUTED": "Trades",
+    "PRIVATE_MARKETS_ORDER_CREATED": "Trades",
     "TRADE_CORRECTED": "Trades",
     "TRADE_INVOICE": "Trades",
     "TRADING_ORDER_CANCELLED": "Trades",
     "TRADING_ORDER_CREATED": "Trades",
-    "private_markets_order_created": "Trades",
-    "trading_order_cancelled": "Trades",
-    "trading_order_created": "Trades",
-    "trading_order_rejected": "Trades",
-    "trading_trade_executed": "Trades",
-    "trading_order_expired": "Trades",
-    "ACQUISITION_TRADE_PERK": "Vorteil",
+    "TRADING_ORDER_EXPIRED": "Trades",
+    "TRADING_ORDER_REJECTED": "Trades",
+    "TRADING_TRADE_EXECUTED": "Trades",
+    "ACQUISITION_TRADE_PERK": "Misc",
     "INTEREST_PAYOUT": "Zinsen",
     "INTEREST_PAYOUT_CREATED": "Zinsen",
 }
@@ -99,7 +127,8 @@ subtitle_subfolder_mapping = {
     "Bardividende": "Dividende",
     "Cash oder Aktie": "Dividende",
     "Dividende Wahlweise": "Dividende",
-    "Aktienprämiendividende": "Misc",
+    "Dividende. Cash oder Stockdividende?": "Dividende",
+    "Aktienprämiendividende": "Dividende",
     "Aktiensplit": "Misc",
     "Aufruf von Zwischenpapieren": "Misc",
     "Bardividende korrigiert": "Misc",
@@ -145,7 +174,6 @@ class DL:
         scan_for_duplicates=False,
         dump_raw_data=False,
         export_transactions=True,
-        history_file="pytr_history",
         max_workers=8,
         universal_filepath=False,
         lang="en",
@@ -154,6 +182,8 @@ class DL:
         sort_export=False,
         format_export: Literal["json", "csv"] = "csv",
         flat=False,
+        load_event_database=None,
+        dry_run=False,
     ):
         """
         tr: api object
@@ -165,7 +195,6 @@ class DL:
         self.filename_fmt = filename_fmt
         self.dump_raw_data = dump_raw_data
         self.export_transactions = export_transactions
-        self.history_file = self.output_path / history_file
         self.universal_filepath = universal_filepath
         self.lang = lang
         self.date_with_time = date_with_time
@@ -173,6 +202,7 @@ class DL:
         self.sort_export = sort_export
         self.format_export: Literal["json", "csv"] = format_export
         self.flat = flat
+        self.dry_run = dry_run
 
         self.tl = Timeline(
             self.tr,
@@ -183,9 +213,12 @@ class DL:
             scan_for_duplicates,
             dump_raw_data,
             self.dl_callback,
+            load_event_database=load_event_database,
         )
 
-        self.session = FuturesSession(max_workers=max_workers, session=self.tr._websession)
+        self.session = (
+            FuturesSession(max_workers=max_workers, session=self.tr._websession) if self.tr is not None else None
+        )
         self.futures: list[Future[Response]] = []
 
         self.events_without_docs: List[Dict[str, Any]] = []
@@ -195,23 +228,11 @@ class DL:
         self.done = 0
         self.filepaths: List[str] = []
         self.doc_urls: List[str] = []
-        self.doc_urls_history: List[str] = []
+        self.events_processed = 0
 
         self.log = get_logger(__name__)
-        self.load_history()
-
-    def load_history(self):
-        """
-        Read history file with URLs if it exists, otherwise create empty file
-        """
-        if self.history_file.exists():
-            with self.history_file.open() as f:
-                self.doc_urls_history = f.read().splitlines()
-            self.log.info(f"Found {len(self.doc_urls_history)} lines in history file")
-        else:
-            self.history_file.parent.mkdir(exist_ok=True, parents=True)
-            self.history_file.touch()
-            self.log.info("Created history file")
+        if load_event_database is not None:
+            self.dry_run = True
 
     def do_dl(self):
         asyncio.run(self.tl.tl_loop())
@@ -239,24 +260,32 @@ class DL:
         self.work_responses()
 
     def dl_callback(self, event):
+        if hasattr(self, "tl") and not self.tl.fetch_from_tr:
+            self.events_processed += 1
+            if self.events_processed % 1000 == 0:
+                self.log.info(f"Processing events: {self.events_processed}/{self.tl.all_detail}")
         has_docs = False
         for section in event["details"]["sections"]:
             if section["type"] != "documents":
                 continue
 
             subfolder = None
-            eventType = event.get("eventType", None)
+            eventType = (event.get("eventType") or "").upper() or None
             title = event.get("title", "")
             subtitle = event.get("subtitle", "")
             eventdesc = f"{title} {subtitle} ({event['id']})"
             sections = event.get("details", {}).get("sections", [{}])
             uebersicht_dict = next(filter(lambda x: x.get("title") in ["Übersicht"], sections), None)
-            if eventType in ["timeline_legacy_migrated_events", None]:
+            if eventType in ["TIMELINE_LEGACY_MIGRATED_EVENTS", None]:
                 subfolder = title_subfolder_mapping.get(title)
                 if subfolder is None:
                     subfolder = subtitle_subfolder_mapping.get(subtitle)
             else:
                 subfolder = event_subfolder_mapping.get(eventType)
+                if subfolder == "Misc":
+                    subtitle_override = subtitle_subfolder_mapping.get(subtitle)
+                    if subtitle_override is not None:
+                        subfolder = subtitle_override
 
             if subfolder is None and uebersicht_dict:
                 for item in uebersicht_dict.get("data", []):
@@ -283,11 +312,19 @@ class DL:
             if subfolder is None:
                 self.log.warning(f"no subfolder mapping for {eventdesc}")
 
+            doc_type_counts = {}
+            for doc in section["data"]:
+                if not isinstance(doc["action"]["payload"], dict):
+                    t = doc["title"].rsplit(" ")
+                    t = " ".join(t[:-1] if t[-1].isnumeric() else t)
+                    doc_type_counts[t] = doc_type_counts.get(t, 0) + 1
+            doc_type_seen = {}
+
             for idx, doc in enumerate(section["data"]):
                 if isinstance(doc["action"]["payload"], dict):
-                    self.log.warning(
-                        f'Download of document with new API-Path URL "{doc["action"]["payload"]["path"]}" is not possible. (yet?)'
-                    )
+                    # self.log.warning(
+                    #     f'Download of document with new API-Path URL "{doc["action"]["payload"]["path"]}" is not possible. (yet?)'
+                    # )
                     continue
                 has_docs = True
                 timestamp_str = event["timestamp"]
@@ -299,17 +336,31 @@ class DL:
                     self.log.warning(f"no timestamp parseable from {timestamp_str}")
                     docdate = datetime.now()
 
-                suffix = f" - {idx}" if idx > 0 else ""
+                t = doc["title"].rsplit(" ")
+                has_num = t[-1].isnumeric()
+                t = " ".join(t[:-1] if has_num else t)
+                doc_type_seen[t] = doc_type_seen.get(t, 0) + 1
+                if not has_num and doc_type_counts[t] > 1 and doc_type_seen[t] > 1:
+                    suffix = f" {doc_type_seen[t]}" if t == "Dokumente" else f" - {doc_type_seen[t] - 1}"
+                else:
+                    suffix = ""
                 title = f"{doc['title']} - {event['title']} - {event['subtitle']}{suffix}"
 
-                self.dl_doc(doc, title, subfolder, docdate)
+                self.dl_doc(
+                    doc,
+                    title,
+                    subfolder,
+                    docdate,
+                    event.get("subtitle") or "",
+                    subdir_override=event["title"] if eventType == "ACQUISITION_TRADE_PERK" else None,
+                )
 
         if has_docs:
             self.events_with_docs.append(event)
         else:
             self.events_without_docs.append(event)
 
-    def dl_doc(self, doc, titleText, subfolder, doc_date):
+    def dl_doc(self, doc, titleText, subfolder, doc_date, subtitle="", subdir_override=None):
         """
         send asynchronous request, append future with filepath to self.futures
         """
@@ -345,7 +396,21 @@ class DL:
             doc_type = " ".join(doc_type)
             if doc_type == "Abrechnung Ausführung" or doc_type == "Abrechnungsausführung":
                 doc_type = "Abrechnung"
+            if doc_type == "Bestätigung eines Ausführungsfehlers":
+                doc_type = "Ausführungsfehler"
             titleText = titleText.replace("\n", "").replace("/", "-")
+            if doc_type == "Dokumente" or doc_type == "Steuerabrechnung":
+                titleText = titleText.removeprefix("Dokumente - ").removeprefix("Steuerabrechnung - ")
+                if subtitle and subfolder == "Misc":
+                    titleText = titleText.removesuffix(f" - {subtitle}")
+            else:
+                titleText = (
+                    titleText.replace("Abrechnung Ausführung - ", "Abrechnung - ")
+                    .replace("Abrechnungsausführung - ", "Abrechnung - ")
+                    .replace("Bestätigung eines Ausführungsfehlers - ", "Ausführungsfehler - ")
+                    .replace(" - Teilnehmen?", "")
+                )
+            titleText = titleText.removesuffix(" - None")
             subtitleText = subtitleText.replace("\n", "").replace("/", "-")
 
             filename = self.filename_fmt.format(
@@ -356,16 +421,29 @@ class DL:
                 doc_num=doc_type_num,
                 id=doc_id,
             )
-
+            filename = filename.rstrip("?")
             # In case, the filename already ends with the doc id, we remove it to avoid a duplicate id in the name
             filename_with_doc_id = filename.removesuffix(doc_id).rstrip() + f" ({doc_id})"
 
             if doc_type in ["Kontoauszug", "Depotauszug"]:
                 filepath = directory / "Abschlüsse" / f"{filename}" / f"{doc_type}.pdf"
                 filepath_with_doc_id = directory / "Abschlüsse" / f"{filename_with_doc_id}" / f"{doc_type}.pdf"
+            elif (
+                doc_type in ["Dokumente", "Steuerabrechnung", "Dividende Wahlweise", "Dividendenbeleg"]
+                or (doc_type == "Transaktionsbestätigung" and subfolder in ["Einzahlungen", "Auszahlungen"])
+                or (subfolder == "Zinsen")
+                or (doc_type == "Abrechnung" and subfolder in ["RoundUp", "Saveback", "Sparplan", "Trades"])
+            ):
+                if subtitle and subfolder == "Misc":
+                    filepath = directory / subtitle / f"{filename}.pdf"
+                    filepath_with_doc_id = directory / subtitle / f"{filename_with_doc_id}.pdf"
+                else:
+                    filepath = directory / f"{filename}.pdf"
+                    filepath_with_doc_id = directory / f"{filename_with_doc_id}.pdf"
             else:
-                filepath = directory / doc_type / f"{filename}.pdf"
-                filepath_with_doc_id = directory / doc_type / f"{filename_with_doc_id}.pdf"
+                subdir = subdir_override if subdir_override is not None else doc_type
+                filepath = directory / subdir / f"{filename}.pdf"
+                filepath_with_doc_id = directory / subdir / f"{filename_with_doc_id}.pdf"
 
             if self.universal_filepath:
                 filepath = sanitize_filepath(filepath, "_", "universal")
@@ -385,18 +463,24 @@ class DL:
         doc["local_filepath"] = str(filepath)
         self.filepaths.append(str(filepath))
 
+        if self.dry_run:
+            if not filepath.exists():
+                filepath.parent.mkdir(parents=True, exist_ok=True)
+                filepath.touch()
+                self.log.debug(f"[dry-run] Created placeholder {filepath}")
+            else:
+                self.log.debug(f"[dry-run] Already exists {filepath}")
+            return
+
         if filepath.is_file() is False:
             doc_url_base = doc_url.split("?")[0]
             if doc_url_base in self.doc_urls:
                 self.log.debug(f"URL {doc_url_base} already in queue. Skipping...")
                 return
-            elif doc_url_base in self.doc_urls_history:
-                self.log.debug(f"URL {doc_url_base} already in history. Skipping...")
-                return
             else:
                 self.doc_urls.append(doc_url_base)
 
-            future = self.session.get(doc_url)
+            future = self.session.get(doc_url)  # type: ignore[union-attr]
             future.filepath = filepath  # type: ignore[attr-defined]
             future.doc_url_base = doc_url_base  # type: ignore[attr-defined]
             self.futures.append(future)  # type: ignore[arg-type]
@@ -412,26 +496,25 @@ class DL:
             self.log.info("Nothing to download.")
             return
 
-        with self.history_file.open("a") as history_file:
-            self.log.info("Waiting for downloads to complete...")
-            for future in as_completed(self.futures):
-                if future.filepath.is_file() is True:  # type: ignore[attr-defined]
-                    self.log.debug(f"file {future.filepath} was already downloaded.")  # type: ignore[attr-defined]
+        self.log.info("Waiting for downloads to complete...")
+        for future in as_completed(self.futures):
+            if future.filepath.is_file() is True:  # type: ignore[attr-defined]
+                self.log.debug(f"file {future.filepath} was already downloaded.")  # type: ignore[attr-defined]
 
-                try:
-                    r = future.result()
-                except Exception as e:
-                    self.log.fatal(str(e))
-                    continue
+            try:
+                r = future.result()
+            except Exception as e:
+                self.log.fatal(str(e))
+                continue
 
-                future.filepath.parent.mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]
-                with open(future.filepath, "wb") as f:  # type: ignore[attr-defined]
-                    f.write(r.content)
-                    self.done += 1
-                    history_file.write(f"{future.doc_url_base}\n")  # type: ignore[attr-defined]
+            future.filepath.parent.mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]
+            with open(future.filepath, "wb") as f:  # type: ignore[attr-defined]
+                f.write(r.content)
+            self.done += 1
+            if self.done % 500 == 0:
+                self.log.info(f"Downloading: {self.done}/{len(self.doc_urls)}")
+            self.log.debug(f"{self.done:>3}/{len(self.doc_urls)} {future.filepath.name}")  # type: ignore[attr-defined]
 
-                    self.log.debug(f"{self.done:>3}/{len(self.doc_urls)} {future.filepath.name}")  # type: ignore[attr-defined]
-
-                if self.done == len(self.doc_urls):
-                    self.log.info("Done.")
-                    return
+            if self.done == len(self.doc_urls):
+                self.log.info("Done.")
+                return

--- a/pytr/event.py
+++ b/pytr/event.py
@@ -212,6 +212,7 @@ events_known_ignored = [
     "PRIVATE_MARKET_FUND_ORDER_RECEIVED",
     "PRIVATE_MARKETS_SUITABILITY_QUIZ_COMPLETED",
     "PUK_CREATED",
+    "QUARTERLY_NET_WORTH_STATEMENT_CREATED",
     "QUARTERLY_REPORT",
     "RDD_FLOW",
     "REFERENCE_ACCOUNT_CHANGED",
@@ -804,7 +805,7 @@ class Event:
                 PPEventType.TRANSFER_IN,
                 PPEventType.TRANSFER_OUT,
             ]
-            and subtitle not in ["Aktienprämiendividende", "Dividende Wahlweise", "Tilgung"]
+            and subtitle not in ["Aktienprämiendividende", "Bardividende korrigiert", "Dividende Wahlweise", "Tilgung"]
         ):
             get_event_logger().warning("Could not parse shares from %s", eventdesc)
             get_event_logger().debug("Failed to parse shares from: %s", json.dumps(event_dict, indent=4))

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -317,6 +317,19 @@ def get_main_parser():
         help="Do not sort documents into folders and keep their original filenames",
         action="store_true",
     )
+    parser_dl_docs.add_argument(
+        "--load-event-database",
+        help="Debug/analysis option: load events from this all_events.json instead of fetching from TR. Implies --dry-run; document URLs in the database may be expired.",
+        metavar="PATH",
+        default=None,
+        type=Path,
+    )
+    parser_dl_docs.add_argument(
+        "--dry-run",
+        default=False,
+        help="Create folder structure and empty placeholder files without downloading",
+        action="store_true",
+    )
 
     # export_transactions
     info = (
@@ -570,7 +583,9 @@ def main():
         ).get()
     elif args.command == "dl_docs":
         DL(
-            login(
+            None
+            if args.load_event_database is not None
+            else login(
                 phone_no=args.phone_no,
                 pin=args.pin,
                 store_credentials=args.store_credentials,
@@ -592,6 +607,8 @@ def main():
             sort_export=args.sort,
             format_export=args.export_format,
             flat=args.flat,
+            load_event_database=args.load_event_database,
+            dry_run=args.dry_run,
         ).do_dl()
     elif args.command == "export_transactions":
         if args.outputfile is None and args.outputdir is None:

--- a/pytr/timeline.py
+++ b/pytr/timeline.py
@@ -49,10 +49,9 @@ class Timeline:
         self.output_path = output_path
         if load_event_database is not None or not_before == -1:
             self.fetch_from_tr = False
-            self.not_before = float(0)
         else:
             self.fetch_from_tr = True
-            self.not_before = not_before
+        self.not_before = float(0) if not_before == -1 else not_before
         self.load_event_database = load_event_database
         self.not_after = not_after
         self.store_event_database = store_event_database
@@ -77,7 +76,6 @@ class Timeline:
 
     async def tl_loop(self):
         if not self.fetch_from_tr:
-            # We might not want to download anything from TR but just create/update account_transactions.csv from available data
             self.finish_timeline_details()
             return
 
@@ -370,5 +368,18 @@ class Timeline:
                 with open(all_events_path, "w", encoding="utf-8") as f:
                     json.dump(self.events, f, ensure_ascii=False, indent=2, default=str)
                 self.log.info("Updated event database.")
+
+        if not self.fetch_from_tr:
+            filtered = [
+                e
+                for e in self.events
+                if "details" in e
+                and datetime.fromisoformat(e["timestamp"][:19]).timestamp() >= self.not_before
+                and datetime.fromisoformat(e["timestamp"][:19]).timestamp() <= self.not_after
+            ]
+            self.log.info(f"Replaying {len(filtered)} events from database (out of {len(self.events)} total)...")
+            self.all_detail = len(filtered)
+            for event in filtered:
+                self.event_callback(event)
 
         self.dl_done = True

--- a/tests/events/aktienpraemiendividende2.json
+++ b/tests/events/aktienpraemiendividende2.json
@@ -1,0 +1,110 @@
+{
+  "id": "1d820d2e-c9d8-38de-98ab-910788874bb5",
+  "timestamp": "2026-07-02T10:41:56.991+0000",
+  "title": "Hensoldt",
+  "icon": "logos/DE000HAG0005/v2",
+  "avatar": {
+    "asset": "logos/DE000HAG0005/v2",
+    "badge": null
+  },
+  "badge": null,
+  "subtitle": "Aktienprämiendividende",
+  "amount": {
+    "currency": "EUR",
+    "value": 0.98,
+    "fractionDigits": 2
+  },
+  "subAmount": null,
+  "status": "CANCELED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "1d820d2e-c9d8-38de-98ab-910788874bb5"
+  },
+  "cashAccountNumber": "123456789",
+  "hidden": false,
+  "deleted": false,
+  "eventType": "SSP_CORPORATE_ACTION_CASH_NON_DIVIDEND",
+  "source": "timelineTransaction",
+  "details": {
+    "id": "1d820d2e-c9d8-38de-98ab-910788874bb5",
+    "sections": [
+      {
+        "title": "Du hast 0,98 € erhalten",
+        "data": {
+          "icon": {
+            "asset": "logos/DE000HAG0005/v2",
+            "badge": null
+          },
+          "subtitleText": "2 Juli · 10:41",
+          "status": "canceled"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Status",
+            "detail": {
+              "text": "Storniert",
+              "functionalStyle": "CANCELED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Event",
+            "detail": {
+              "text": "Aktienprämiendividende",
+              "displayValue": {
+                "text": "Aktienprämiendividende",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Wertpapier",
+            "detail": {
+              "text": "Hensoldt",
+              "displayValue": {
+                "text": "Hensoldt",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Dokumente",
+            "detail": "02.07.2026",
+            "action": {
+              "payload": "https://example.com/pb1782989599488139633943454541.pdf",
+              "type": "browserModal"
+            },
+            "id": "04c7d864-de68-4133-aa38-cdf77655baf2",
+            "postboxType": "CA_INCOME_INVOICE"
+          },
+          {
+            "title": "Dokumente",
+            "detail": "27.05.2026",
+            "action": {
+              "payload": "https://example.com/pb17798719140201365610066326.pdf",
+              "type": "browserModal"
+            },
+            "id": "964c98d8-3a87-44d1-9217-10bd675347fb",
+            "postboxType": "CA_INCOME_INVOICE"
+          }
+        ],
+        "type": "documents"
+      }
+    ]
+  }
+}

--- a/tests/events/aktiensplit2.json
+++ b/tests/events/aktiensplit2.json
@@ -1,0 +1,100 @@
+{
+  "id": "bf903d2e-8353-3a00-94dd-312a876a0ab1",
+  "timestamp": "2026-07-02T06:31:26.598+0000",
+  "title": "Crowdstrike Holdings (A)",
+  "icon": "logos/US22788C1053/v2",
+  "subtitle": "Aktiensplit",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "bf903d2e-8353-3a00-94dd-312a876a0ab1"
+  },
+  "trailing": null,
+  "eventType": "SSP_CORPORATE_ACTION_NO_CASH",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "bf903d2e-8353-3a00-94dd-312a876a0ab1",
+    "sections": [
+      {
+        "title": "Du hast Aktien aus einer Kapitalmaßnahme erhalten",
+        "data": {
+          "icon": {
+            "asset": "logos/US22788C1053/v2",
+            "badge": null
+          },
+          "subtitleText": "2 Juli · 06:31",
+          "status": "executed"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Status",
+            "detail": {
+              "text": "Ausgeführt",
+              "functionalStyle": "EXECUTED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Orderart",
+            "detail": {
+              "text": "Aktiensplit",
+              "displayValue": {
+                "text": "Aktiensplit",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Wertpapier",
+            "detail": {
+              "text": "Crowdstrike Holdings (A)",
+              "displayValue": {
+                "text": "Crowdstrike Holdings (A)",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Aktien hinzugefügt",
+            "detail": {
+              "text": "0.688026",
+              "displayValue": {
+                "text": "0.688026",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Dokumente",
+            "detail": "02.07.2026",
+            "action": {
+              "payload": "https://example.com/pb178297411197790182675288721.pdf",
+              "type": "browserModal"
+            },
+            "id": "03c70be5-854b-4994-b73c-e9230791b6af",
+            "postboxType": "CA_SECURITIES_INVOICE"
+          }
+        ],
+        "type": "documents"
+      }
+    ]
+  }
+}

--- a/tests/events/bardividende_korrigiert2.json
+++ b/tests/events/bardividende_korrigiert2.json
@@ -1,0 +1,80 @@
+{
+  "id": "dfe3fa0d-be9f-30aa-b50e-6efdf27ecb1d",
+  "timestamp": "2026-06-26T13:51:37.901+0000",
+  "title": "Medical Properties Trust",
+  "icon": "logos/US58463J3041/v2",
+  "avatar": {
+    "asset": "logos/US58463J3041/v2",
+    "badge": null
+  },
+  "badge": null,
+  "subtitle": "Bardividende korrigiert",
+  "amount": {
+    "currency": "EUR",
+    "value": 0.37,
+    "fractionDigits": 2
+  },
+  "subAmount": null,
+  "status": "EXECUTED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "dfe3fa0d-be9f-30aa-b50e-6efdf27ecb1d"
+  },
+  "cashAccountNumber": "123456789",
+  "hidden": false,
+  "deleted": false,
+  "eventType": "SSP_CORPORATE_ACTION_CASH",
+  "source": "timelineTransaction",
+  "details": {
+    "id": "dfe3fa0d-be9f-30aa-b50e-6efdf27ecb1d",
+    "sections": [
+      {
+        "type": "header",
+        "title": "Du hast 0,37 € erhalten",
+        "data": {
+          "status": "executed",
+          "icon": "logos/US58463J3041/v2",
+          "timestamp": "2026-06-26T13:51:37.901118Z"
+        }
+      },
+      {
+        "type": "table",
+        "title": "Überblick",
+        "data": [
+          {
+            "title": "Status",
+            "style": "plain",
+            "detail": {
+              "type": "status",
+              "text": "Ausgeführt",
+              "functionalStyle": "EXECUTED"
+            }
+          },
+          {
+            "title": "Vermögenswert",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Medical Properties Trust"
+            }
+          }
+        ]
+      },
+      {
+        "type": "documents",
+        "title": "Dokumente",
+        "data": [
+          {
+            "id": "ec8f5ff2-9a6d-42f7-bdb7-e2efcdb0a991",
+            "title": "Dividendenbeleg",
+            "action": {
+              "type": "browserModal",
+              "payload": "https://example.com/pb178248205762239248901284987.pdf"
+            },
+            "postboxType": "INVOICE"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/events/dividende_wahlweise2.json
+++ b/tests/events/dividende_wahlweise2.json
@@ -1,0 +1,76 @@
+{
+  "id": "536a5126-a287-46c4-aee5-2c4746809d8c",
+  "timestamp": "2024-11-05T16:48:48.463+0000",
+  "title": "Unilever",
+  "icon": "logos/GB00B10RZP78/v2",
+  "subtitle": "Dividende. Cash oder Stockdividende?",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "536a5126-a287-46c4-aee5-2c4746809d8c"
+  },
+  "trailing": null,
+  "eventType": "SSP_CORPORATE_ACTION_ACTIVITY",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "536a5126-a287-46c4-aee5-2c4746809d8c",
+    "sections": [
+      {
+        "title": "Du hast eine bevorstehende Dividendenzahlung",
+        "data": {
+          "icon": {
+            "asset": "logos/GB00B10RZP78/v2",
+            "badge": null
+          },
+          "subtitleText": "5 Nov. 2024 · 16:48",
+          "status": "executed"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Status",
+            "detail": {
+              "text": "Ausstehend",
+              "functionalStyle": "PENDING",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Wertpapier",
+            "detail": {
+              "text": "Unilever",
+              "displayValue": {
+                "text": "Unilever",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Dividende Wahlweise",
+            "detail": "05.11.2024",
+            "action": {
+              "payload": "https://example.com/pb173082660789413143540778822817.pdf",
+              "type": "browserModal"
+            },
+            "id": "063c02e6-b4b0-4972-aea6-940df2ef0e24",
+            "postboxType": "CA_DIVIDEND_OPTION"
+          }
+        ],
+        "type": "documents"
+      }
+    ]
+  }
+}

--- a/tests/events/dividende_wahlweise3.json
+++ b/tests/events/dividende_wahlweise3.json
@@ -1,0 +1,82 @@
+{
+  "id": "5ba0acbb-df94-4965-a977-09739dcd36fa",
+  "timestamp": "2026-07-29T13:38:12.570+0000",
+  "title": "Rio Tinto",
+  "icon": "logos/AU000000RIO1/v2",
+  "subtitle": "Dividende. Cash oder Stockdividende?",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "5ba0acbb-df94-4965-a977-09739dcd36fa"
+  },
+  "trailing": null,
+  "eventType": "SSP_CORPORATE_ACTION_INSTRUCTION",
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "5ba0acbb-df94-4965-a977-09739dcd36fa",
+    "sections": [
+      {
+        "type": "header",
+        "title": "Du hast eine bevorstehende Dividendenzahlung",
+        "data": {
+          "status": "executed",
+          "icon": "logos/AU000000RIO1/v2",
+          "timestamp": "2026-07-29T13:38:12.570034Z"
+        }
+      },
+      {
+        "type": "table",
+        "title": "Überblick",
+        "data": [
+          {
+            "title": "Status",
+            "style": "plain",
+            "detail": {
+              "type": "status",
+              "text": "Ausstehend",
+              "functionalStyle": "PENDING"
+            }
+          },
+          {
+            "title": "Vermögenswert",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Rio Tinto",
+              "displayValue": {
+                "text": "Rio Tinto"
+              }
+            }
+          },
+          {
+            "title": "Ereignis",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Dividende Wahlweise",
+              "displayValue": {
+                "text": "Dividende Wahlweise"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "documents",
+        "title": "Dokumente",
+        "data": [
+          {
+            "id": "cea3db89-128b-4069-b4f2-fd831b656231",
+            "title": "Dividende Wahlweise",
+            "action": {
+              "type": "browserModal",
+              "payload": "https://example.com/pb1785332375898143002307863481.pdf"
+            },
+            "postboxType": "DIVIDEND_OPTION_NOTIFICATION"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/events/verkaufsorder_abrechnung12.json
+++ b/tests/events/verkaufsorder_abrechnung12.json
@@ -1,0 +1,138 @@
+{
+  "id": "7ca12567-d1a3-4b9e-9ff9-860a8b1039da",
+  "timestamp": "2026-05-18T15:37:40.852+0000",
+  "title": "Zalando",
+  "icon": "logos/DE000ZAL1111/v2",
+  "avatar": {
+    "asset": "logos/DE000ZAL1111/v2",
+    "badge": null
+  },
+  "badge": null,
+  "subtitle": "Verkaufsorder",
+  "amount": {
+    "currency": "EUR",
+    "value": 93.07,
+    "fractionDigits": 2
+  },
+  "subAmount": null,
+  "status": "EXECUTED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "7ca12567-d1a3-4b9e-9ff9-860a8b1039da"
+  },
+  "cashAccountNumber": "123456789",
+  "hidden": false,
+  "deleted": false,
+  "eventType": "TRADING_TRADE_EXECUTED",
+  "source": "timelineTransaction",
+  "details": {
+    "id": "7ca12567-d1a3-4b9e-9ff9-860a8b1039da",
+    "sections": [
+      {
+        "title": "Du hast 93,07 € erhalten",
+        "data": {
+          "icon": {
+            "asset": "logos/DE000ZAL1111/v2",
+            "badge": null
+          },
+          "timestamp": "2026-05-18T15:37:40.85271Z",
+          "status": "executed"
+        },
+        "action": {
+          "payload": "DE000ZAL1111",
+          "type": "instrumentDetail"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Verkaufen",
+            "detail": {
+              "text": "Ausgeführt",
+              "functionalStyle": "EXECUTED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Asset",
+            "detail": {
+              "text": "Zalando",
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Aktien",
+            "detail": {
+              "text": "4,795804",
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Gebühr",
+            "detail": {
+              "text": "1,00 €",
+              "type": "text"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Summe",
+            "detail": {
+              "text": "93,07 €",
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Abrechnung 1",
+            "action": {
+              "payload": "https://example.com/pb177912741843111361132997312.pdf",
+              "type": "browserModal"
+            },
+            "id": "c296d1ff-1c41-4d78-9f78-ebfd36c1aa4a",
+            "postboxType": "SECURITIES_SETTLEMENT"
+          },
+          {
+            "title": "Abrechnung 2",
+            "action": {
+              "payload": "https://example.com/pb177912741845833861871511777.pdf",
+              "type": "browserModal"
+            },
+            "id": "878d892d-e423-4276-bd92-1be56378ddae",
+            "postboxType": "SECURITIES_SETTLEMENT"
+          },
+          {
+            "title": "Kosteninformation 1",
+            "action": {
+              "payload": "https://example.com/pb17791186615264608177800718.pdf",
+              "type": "browserModal"
+            },
+            "id": "6fefbcb8-b090-42fe-9a2e-082c448be84b",
+            "postboxType": "EQUITIES_SELL_EX_ANTE"
+          },
+          {
+            "title": "Kosteninformation 2",
+            "action": {
+              "payload": "https://example.com/pb177911866152618856175389832.pdf",
+              "type": "browserModal"
+            },
+            "id": "7f65bb06-b16a-4cc1-8ba3-a4423ec4b9a0",
+            "postboxType": "EQUITIES_SELL_EX_ANTE"
+          }
+        ],
+        "type": "documents"
+      }
+    ]
+  }
+}

--- a/tests/test_dl_paths.py
+++ b/tests/test_dl_paths.py
@@ -1,0 +1,394 @@
+"""Tests for dl_docs download target path computation.
+
+Loads real fixtures from tests/events/, calls dl_callback(), and checks
+the local_filepath assigned to each downloadable document.
+No network or TR connection needed — DL is constructed without one.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from pytr.dl import DL
+
+EVENTS_DIR = Path(__file__).parent / "events"
+FMT = "{iso_date} {time} {title}"
+
+
+def make_dl(tmp_path: Path) -> DL:
+    dl = DL.__new__(DL)
+    dl.tr = None
+    dl.output_path = tmp_path
+    dl.filename_fmt = FMT
+    dl.flat = False
+    dl.universal_filepath = True
+    dl.dry_run = True
+    dl.filepaths = []
+    dl.doc_urls = []
+    dl.futures = []
+    dl.events_with_docs = []
+    dl.events_without_docs = []
+    dl.docs_request = 0
+    dl.done = 0
+    dl.events_processed = 0
+    dl.session = None
+    dl.log = logging.getLogger("test_dl_paths")
+    return dl
+
+
+def collect_paths(fixture_name: str, tmp_path: Path) -> list[str]:
+    """Run dl_callback on a fixture; return relative posix paths of assigned documents."""
+    dl = make_dl(tmp_path)
+    with open(EVENTS_DIR / fixture_name, encoding="utf-8") as f:
+        event = json.load(f)
+    dl.dl_callback(event)
+    result = []
+    for section in event["details"]["sections"]:
+        if section["type"] != "documents":
+            continue
+        for doc in section["data"]:
+            if "local_filepath" in doc:
+                result.append(Path(doc["local_filepath"]).relative_to(tmp_path).as_posix())
+    return result
+
+
+test_data: list[dict] = [
+    # --- Trades: eventType-mapped ---
+    {
+        "filename": "buy.json",
+        # ORDER_EXECUTED → Trades/; three distinct doc types
+        # Note: universal_filepath=True replaces ":" with "_" in the time component
+        "paths": [
+            "Trades/2024-02-20 16_32 Abrechnung - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+            "Trades/Basisinformationsblatt/2024-02-20 16_32 Basisinformationsblatt - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+            "Trades/Kosteninformation/2024-02-20 16_32 Kosteninformation - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+        ],
+    },
+    {
+        "filename": "trade_invoice.json",
+        # TRADE_INVOICE → Trades/
+        "paths": [
+            "Trades/2024-06-04 06_23 Abrechnung - DWS Group - Limit-Buy-Order.pdf",
+            "Trades/Auftragsbestätigung/2024-06-04 06_23 Auftragsbestätigung - DWS Group - Limit-Buy-Order.pdf",
+            "Trades/Kosteninformation/2024-06-04 06_23 Kosteninformation - DWS Group - Limit-Buy-Order.pdf",
+        ],
+    },
+    {
+        "filename": "buy_new.json",
+        # trading_trade_executed (normalised → TRADING_TRADE_EXECUTED) → Trades/
+        "paths": [
+            "Trades/2025-10-10 19_29 Abrechnung - NVIDIA - Kauforder.pdf",
+            "Trades/Kosteninformation/2025-10-10 19_29 Kosteninformation - NVIDIA - Kauforder.pdf",
+        ],
+    },
+    {
+        "filename": "limit-sell-order.json",
+        # trading_trade_executed → Trades/
+        "paths": [
+            "Trades/Auftragsbestätigung/2025-05-20 08_03 Auftragsbestätigung - D-Wave Quantum - Limit-Sell-Order.pdf",
+            "Trades/Kosteninformation/2025-05-20 08_03 Kosteninformation - D-Wave Quantum - Limit-Sell-Order.pdf",
+            "Trades/2025-05-20 08_03 Abrechnung - D-Wave Quantum - Limit-Sell-Order.pdf",
+        ],
+    },
+    {
+        "filename": "bond_kauf.json",
+        # TRADING_TRADE_EXECUTED; fixture has "Kosteninformation 1/2", "Abrechnung 1/2"
+        # Number in title already differentiates → no dedup suffix
+        "paths": [
+            "Trades/Kosteninformation/2025-07-18 08_04 Kosteninformation 1 - Juli 2040 - Kauforder.pdf",
+            "Trades/Kosteninformation/2025-07-18 08_04 Kosteninformation 2 - Juli 2040 - Kauforder.pdf",
+            "Trades/2025-07-18 08_04 Abrechnung 1 - Juli 2040 - Kauforder.pdf",
+            "Trades/2025-07-18 08_04 Abrechnung 2 - Juli 2040 - Kauforder.pdf",
+        ],
+    },
+    {
+        "filename": "verkaufsorder_abrechnung12.json",
+        # TRADING_TRADE_EXECUTED; "Abrechnung 1/2", "Kosteninformation 1/2"
+        # Number in title already differentiates → no dedup suffix; Abrechnung flat in Trades/
+        "paths": [
+            "Trades/2026-05-18 15_37 Abrechnung 1 - Zalando - Verkaufsorder.pdf",
+            "Trades/2026-05-18 15_37 Abrechnung 2 - Zalando - Verkaufsorder.pdf",
+            "Trades/Kosteninformation/2026-05-18 15_37 Kosteninformation 1 - Zalando - Verkaufsorder.pdf",
+            "Trades/Kosteninformation/2026-05-18 15_37 Kosteninformation 2 - Zalando - Verkaufsorder.pdf",
+        ],
+    },
+    {
+        "filename": "trade_corrected.json",
+        # TRADE_CORRECTED → Trades/; fixture docs named "Abrechnung 2" / "Abrechnung 1"
+        # Number in title already differentiates → no dedup suffix
+        "paths": [
+            "Trades/2024-12-16 09_59 Abrechnung 2 - Worldline - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/2024-12-16 09_59 Abrechnung 1 - Worldline - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/Auftragsbestätigung/2024-12-16 09_59 Auftragsbestätigung - Worldline - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/Kosteninformation/2024-12-16 09_59 Kosteninformation - Worldline - Limit Verkauf-Order neu abgerechnet.pdf",
+        ],
+    },
+    {
+        "filename": "savingsplan.json",
+        # trading_savingsplan_executed → Sparplan/; Abrechnungsausführung → normalised to Abrechnung
+        "paths": [
+            "Sparplan/2025-10-23 08_26 Abrechnung - DroneShield - Sparplan ausgeführt.pdf",
+        ],
+    },
+    {
+        "filename": "trading_savingsplan_executed.json",
+        # TRADING_SAVINGSPLAN_EXECUTED → Sparplan/
+        "paths": [
+            "Sparplan/2025-02-10 09_23 Abrechnung - BASF - Sparplan ausgeführt.pdf",
+        ],
+    },
+    {
+        "filename": "savings_plan_invoice_created.json",
+        # SAVINGS_PLAN_INVOICE_CREATED → Sparplan/; Abrechnung Ausführung → normalised to Abrechnung
+        "paths": [
+            "Sparplan/2024-06-17 08_16 Abrechnung - Volkswagen (Vz.) - Sparplan ausgeführt.pdf",
+        ],
+    },
+    {
+        "filename": "ipo-spacex.json",
+        # IPO_TRADE_EXECUTED → Trades/
+        "paths": [
+            "Trades/2026-06-06 04_20 Abrechnung - SpaceX - IPO.pdf",
+            "Trades/Kosteninformation/2026-06-06 04_20 Kosteninformation - SpaceX - IPO.pdf",
+            "Trades/Prospekt/2026-06-06 04_20 Prospekt - SpaceX - IPO.pdf",
+        ],
+    },
+    # --- Trades: no-eventType / legacy subtitle fallback ---
+    {
+        "filename": "buy_no_eventType.json",
+        # No eventType, subtitle=Kauforder → subtitle_subfolder_mapping → Trades/
+        "paths": [
+            "Trades/2024-02-20 16_32 Abrechnung - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+            "Trades/Basisinformationsblatt/2024-02-20 16_32 Basisinformationsblatt - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+            "Trades/Kosteninformation/2024-02-20 16_32 Kosteninformation - Euro Stoxx 50 EUR (Dist) - Kauforder.pdf",
+        ],
+    },
+    {
+        "filename": "legacy_verkauforder_neu_abgerechnet.json",
+        # TIMELINE_LEGACY_MIGRATED_EVENTS, subtitle → Trades/
+        # fixture docs named "Abrechnung 2" / "Abrechnung 1"; number differentiates → no dedup suffix
+        "paths": [
+            "Trades/2025-02-21 11_14 Abrechnung 2 - Marie Brizard Wine and Spirits - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/2025-02-21 11_14 Abrechnung 1 - Marie Brizard Wine and Spirits - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/Auftragsbestätigung/2025-02-21 11_14 Auftragsbestätigung - Marie Brizard Wine and Spirits - Limit Verkauf-Order neu abgerechnet.pdf",
+            "Trades/Kosteninformation/2025-02-21 11_14 Kosteninformation - Marie Brizard Wine and Spirits - Limit Verkauf-Order neu abgerechnet.pdf",
+        ],
+    },
+    # --- Dividends ---
+    {
+        "filename": "dividende_wahlweise2.json",
+        # SSP_CORPORATE_ACTION_ACTIVITY → Misc, subtitle override → Dividende/; flat (like Dokumente)
+        "paths": [
+            "Dividende/2024-11-05 16_48 Dividende Wahlweise - Unilever - Dividende. Cash oder Stockdividende.pdf",
+        ],
+    },
+    {
+        "filename": "dividende_wahlweise3.json",
+        # SSP_CORPORATE_ACTION_INSTRUCTION → Misc, subtitle override → Dividende/; flat (like Dokumente)
+        "paths": [
+            "Dividende/2026-07-29 13_38 Dividende Wahlweise - Rio Tinto - Dividende. Cash oder Stockdividende.pdf",
+        ],
+    },
+    {
+        "filename": "bardividende.json",
+        # ssp_corporate_action_invoice_cash → Dividende/; doc type Dokumente → flat under subfolder
+        "paths": [
+            "Dividende/2025-10-23 14_19 Comcast (A) - Bardividende.pdf",
+        ],
+    },
+    {
+        "filename": "bardividende_no_eventType.json",
+        # No eventType, subtitle=Bardividende → Dividende/
+        "paths": [
+            "Dividende/2025-11-05 18_31 Lowe's - Bardividende.pdf",
+        ],
+    },
+    {
+        "filename": "bardividende_korrigiert2.json",
+        # SSP_CORPORATE_ACTION_CASH → Dividende/; doc title Dividendenbeleg → flat (like Dokumente)
+        "paths": [
+            "Dividende/2026-06-26 13_51 Dividendenbeleg - Medical Properties Trust - Bardividende korrigiert.pdf",
+        ],
+    },
+    {
+        "filename": "aktiendividende.json",
+        # ssp_corporate_action_invoice_shares → Misc, but subtitle Aktiendividende overrides → Dividende/
+        "paths": [
+            "Dividende/2025-07-22 14_31 Enovix - Aktiendividende.pdf",
+        ],
+    },
+    {
+        "filename": "aktienpraemiendividende.json",
+        # ssp_corporate_action_invoice_cash → Dividende/ (via subtitle_subfolder_mapping); doc: Dokumente → flat
+        "paths": [
+            "Dividende/2025-09-22 11_20 Glencore - Aktienprämiendividende.pdf",
+        ],
+    },
+    {
+        "filename": "aktienpraemiendividende2.json",
+        # SSP_CORPORATE_ACTION_CASH_NON_DIVIDEND → Misc, subtitle Aktienprämiendividende overrides → Dividende/
+        # Two Dokumente docs → second gets counter " 2" appended
+        "paths": [
+            "Dividende/2026-07-02 10_41 Hensoldt - Aktienprämiendividende.pdf",
+            "Dividende/2026-07-02 10_41 Hensoldt - Aktienprämiendividende 2.pdf",
+        ],
+    },
+    {
+        "filename": "vorabpauschale.json",
+        # ssp_corporate_action_invoice_cash → Dividende/; doc title Vorabpauschale (not Dokumente) → subdir
+        "paths": [
+            "Dividende/Vorabpauschale/2025-01-28 14_54 Vorabpauschale - MSCI China USD (Acc) - Vorabpauschale.pdf",
+        ],
+    },
+    # --- Transfers / payments ---
+    {
+        "filename": "bank_transaction_incoming.json",
+        # BANK_TRANSACTION_INCOMING → Einzahlungen/; flat (like Dokumente)
+        "paths": [
+            "Einzahlungen/2024-07-04 06_17 Transaktionsbestätigung - Max Mustermann - Fertig.pdf",
+        ],
+    },
+    {
+        "filename": "bank_transaction_outgoing.json",
+        # BANK_TRANSACTION_OUTGOING → Auszahlungen/; flat (like Dokumente)
+        "paths": [
+            "Auszahlungen/2024-07-21 09_35 Transaktionsbestätigung - Max Mustermann - Gesendet.pdf",
+        ],
+    },
+    {
+        "filename": "incoming_transfer.json",
+        # INCOMING_TRANSFER → Einzahlungen/; flat (like Dokumente)
+        "paths": [
+            "Einzahlungen/2024-09-02 17_49 Transaktionsbestätigung - Klaus Mustermann - Fertig.pdf",
+        ],
+    },
+    {
+        "filename": "outgoing_transfer.json",
+        # OUTGOING_TRANSFER → Auszahlungen/; flat (like Dokumente)
+        "paths": [
+            "Auszahlungen/2024-07-21 09_35 Transaktionsbestätigung - Hans Mustermann - Gesendet.pdf",
+        ],
+    },
+    # --- Interest ---
+    {
+        "filename": "interest_payout_created.json",
+        # INTEREST_PAYOUT_CREATED → Zinsen/; flat
+        "paths": [
+            "Zinsen/2024-07-01 04_51 Abrechnung - Zinsen.pdf",
+        ],
+    },
+    {
+        "filename": "legacy_zinsen.json",
+        # TIMELINE_LEGACY_MIGRATED_EVENTS, title=Zinsen → title_subfolder_mapping → Zinsen/; flat
+        "paths": [
+            "Zinsen/2024-09-01 16_39 Abrechnung - Zinsen.pdf",
+        ],
+    },
+    {
+        "filename": "legacy_zinsen_no_eventType.json",
+        # no eventType, title=Zinsen → title_subfolder_mapping → Zinsen/; flat
+        "paths": [
+            "Zinsen/2024-09-01 16_39 Abrechnung - Zinsen.pdf",
+        ],
+    },
+    # --- Steuerkorrektur ---
+    {
+        "filename": "steuerkorrektur.json",
+        # ssp_tax_correction_invoice → Steuerkorrekturen/; Steuerabrechnung → flat (like Dokumente)
+        "paths": [
+            "Steuerkorrekturen/2025-10-28 00_00 Steuerkorrektur.pdf",
+        ],
+    },
+    {
+        "filename": "ssp_tax_correction.json",
+        # SSP_TAX_CORRECTION → Steuerkorrekturen/
+        "paths": [
+            "Steuerkorrekturen/2024-06-11 22_45 Steuerkorrektur.pdf",
+        ],
+    },
+    {
+        "filename": "steuerkorrektur_no_eventType.json",
+        # No eventType, title=Steuerkorrektur → title_subfolder_mapping → Steuerkorrekturen/
+        "paths": [
+            "Steuerkorrekturen/2025-11-04 23_31 Steuerkorrektur.pdf",
+        ],
+    },
+    # --- Saveback / RoundUp ---
+    {
+        "filename": "saveback_aggregate.json",
+        # SAVEBACK_AGGREGATE → Saveback/; Abrechnung Ausführung → normalised to Abrechnung
+        "paths": [
+            "Saveback/2024-07-02 13_53 Abrechnung - S&P 500 Information Tech USD (Acc) - Saveback.pdf",
+            "Saveback/Kosteninformation/2024-07-02 13_53 Kosteninformation - S&P 500 Information Tech USD (Acc) - Saveback.pdf",
+        ],
+    },
+    {
+        "filename": "spare_change_aggregate.json",
+        # SPARE_CHANGE_AGGREGATE → RoundUp/; Abrechnung Ausführung → normalised to Abrechnung
+        "paths": [
+            "RoundUp/2024-06-10 13_52 Abrechnung - S&P 500 Information Tech USD (Acc) - Round up.pdf",
+            "RoundUp/Kosteninformation/2024-06-10 13_52 Kosteninformation - S&P 500 Information Tech USD (Acc) - Round up.pdf",
+        ],
+    },
+    # --- Corporate actions ---
+    {
+        "filename": "aktienbonus.json",
+        # ACQUISITION_TRADE_PERK → Misc/; title becomes subdir
+        "paths": [
+            "Misc/Aktien-Bonus/2025-10-13 14_49 Kosteninformation - Aktien-Bonus - Eingelöst.pdf",
+            "Misc/Aktien-Bonus/2025-10-13 14_49 Rechnung - Aktien-Bonus - Eingelöst.pdf",
+        ],
+    },
+    {
+        "filename": "trade_perk.json",
+        # ACQUISITION_TRADE_PERK → Misc/; title becomes subdir
+        "paths": [
+            "Misc/Aktien-Bonus/2025-04-01 14_09 Rechnung - Aktien-Bonus - Eingelöst.pdf",
+            "Misc/Aktien-Bonus/2025-04-01 14_09 Kosteninformation - Aktien-Bonus - Eingelöst.pdf",
+        ],
+    },
+    # --- Corporate actions ---
+    {
+        "filename": "aktiensplit.json",
+        # ssp_corporate_action_invoice_shares → Misc/; Dokumente + Misc → subtitle becomes subdir
+        "paths": [
+            "Misc/Aktiensplit/2024-06-26 08_06 Chipotle Mexican Grill.pdf",
+        ],
+    },
+    {
+        "filename": "aktiensplit2.json",
+        # SSP_CORPORATE_ACTION_NO_CASH → Misc/; Dokumente + Misc → subtitle becomes subdir
+        "paths": [
+            "Misc/Aktiensplit/2026-07-02 06_31 Crowdstrike Holdings (A).pdf",
+        ],
+    },
+    {
+        "filename": "spinoff.json",
+        # ssp_corporate_action_invoice_shares → Misc/; Dokumente + Misc → subtitle becomes subdir
+        "paths": [
+            "Misc/Spin-off/2025-10-20 11_25 ThyssenKrupp.pdf",
+        ],
+    },
+    {
+        "filename": "private_markets_trade.json",
+        # private_markets_trade_executed (normalised → PRIVATE_MARKETS_TRADE_EXECUTED) → Trades/
+        "paths": [
+            "Trades/Kosteninformation/2025-09-18 07_14 Kosteninformation - Private Equity - Kauforder.pdf",
+            "Trades/2025-09-18 07_14 Abrechnung - Private Equity - Kauforder.pdf",
+        ],
+    },
+    {
+        "filename": "private_markets_vorabpauschale.json",
+        # SSP_CORPORATE_ACTION_CASH_NON_DIVIDEND → Misc/; doc: Vorabpauschale (not Dokumente) → subdir
+        "paths": [
+            "Misc/Vorabpauschale/2026-03-09 07_56 Vorabpauschale - Private Equity - Vorabpauschale.pdf",
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("case", test_data, ids=[c["filename"] for c in test_data])
+def test_dl_paths(case, tmp_path):
+    assert collect_paths(case["filename"], tmp_path) == case["paths"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,2585 +1,2646 @@
 import json
+from pathlib import Path
+
+import pytest
 
 from pytr.event import ConditionalEventType, Event, PPEventType
 from pytr.transactions import TransactionExporter
 
+EVENTS_DIR = Path(__file__).parent / "events"
 
-def test_events():
-    test_data = [
-        {
-            "filename": "address_changed.json",
-            "event_type": None,
-        },
-        {
-            "filename": "aktien_entfernt.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "ORSTED A/S   -ANR-",
-            "isin": "DK0064307839",
-            "shares": 0.285835,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-10-28T15:46:46",
-                    "Typ": "Verkauf",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "ISIN": "DK0064307839",
-                    "Stück": 0.285835,
-                }
-            ],
-        },
-        {
-            "filename": "aktien_entfernt_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "ORSTED A/S   -ANR-",
-            "isin": "DK0064307839",
-            "shares": 0.285835,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-10-28T15:46:46",
-                    "Typ": "Verkauf",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "ISIN": "DK0064307839",
-                    "Stück": 0.285835,
-                }
-            ],
-        },
-        {
-            "filename": "aktien_entfernt2.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "WORLDLINE S.A. ANR",
-            "isin": "FR0014015MS9",
-            "shares": 0.299376,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2026-04-03T10:48:40",
-                    "Typ": "Verkauf",
-                    "Wert": 0,
-                    "Notiz": "WORLDLINE S.A. ANR",
-                    "ISIN": "FR0014015MS9",
-                    "Stück": 0.299376,
-                }
-            ],
-        },
-        {
-            "filename": "aktienbonus.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "Aktien-Bonus",
-            "isin": "US2546871060",
-            "shares": 0.105,
-            "value": -10.03,
-            "transactions": [
-                {
-                    "Datum": "2025-10-13T14:49:06",
-                    "Typ": "Kauf",
-                    "Wert": -10.03,
-                    "Notiz": "Aktien-Bonus",
-                    "ISIN": "US2546871060",
-                    "Stück": 0.105,
-                },
-                {
-                    "Datum": "2025-10-13T14:49:06",
-                    "Typ": "Einlage",
-                    "Wert": 10.03,
-                    "Notiz": "Aktien-Bonus",
-                },
-            ],
-        },
-        {
-            "filename": "aktienbonus_no_eventType.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "Aktien-Bonus",
-            "isin": "US2546871060",
-            "shares": 0.105,
-            "value": -10.03,
-            "transactions": [
-                {
-                    "Datum": "2025-10-13T14:49:06",
-                    "Typ": "Kauf",
-                    "Wert": -10.03,
-                    "Notiz": "Aktien-Bonus",
-                    "ISIN": "US2546871060",
-                    "Stück": 0.105,
-                },
-                {
-                    "Datum": "2025-10-13T14:49:06",
-                    "Typ": "Einlage",
-                    "Wert": 10.03,
-                    "Notiz": "Aktien-Bonus",
-                },
-            ],
-        },
-        {
-            "filename": "aktiendividende.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "Enovix",
-            "isin": "US2935941318",
-            "isin2": "US2935941078",
-            "shares": 0.494370,
-            "value": 0,
-            "note": "Enovix Corp. WTS 01.10.26",
-            "transactions": [
-                {
-                    "Datum": "2025-07-22T14:31:49",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "Enovix Corp. WTS 01.10.26",
-                    "ISIN": "US2935941318",
-                    "Stück": 0.494370,
-                    "ISIN2": "US2935941078",
-                }
-            ],
-        },
-        {
-            "filename": "aktiendividende_no_eventType.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "Enovix",
-            "isin": "US2935941318",
-            "isin2": "US2935941078",
-            "shares": 0.494370,
-            "value": 0,
-            "note": "Enovix Corp. WTS 01.10.26",
-            "transactions": [
-                {
-                    "Datum": "2025-07-22T14:31:49",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "Enovix Corp. WTS 01.10.26",
-                    "ISIN": "US2935941318",
-                    "Stück": 0.494370,
-                    "ISIN2": "US2935941078",
-                }
-            ],
-        },
-        {
-            "filename": "aktiendividende_only_taxes.json",
-            "event_type": PPEventType.TAXES,
-            "title": "Enovix Corp. WTS 01.10.26",
-            "isin": "US2935941318",
-            "value": -0.57,
-            "taxes": 0.57,
-            "transactions": [
-                {
-                    "Datum": "2026-01-06T16:14:51",
-                    "Typ": "Steuern",
-                    "Wert": -0.57,
-                    "Notiz": "Enovix Corp. WTS 01.10.26",
-                    "ISIN": "US2935941318",
-                    "Steuern": 0.57,
-                }
-            ],
-        },
-        {
-            "filename": "aktienpraemiendividende.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Glencore",
-            "isin": "JE00B4T3BW64",
-            "value": 3,
-            "taxes": 1.15,
-            "transactions": [
-                {
-                    "Datum": "2025-09-22T11:20:31",
-                    "Typ": "Dividende",
-                    "Wert": 3.0,
-                    "Notiz": "Glencore",
-                    "ISIN": "JE00B4T3BW64",
-                    "Steuern": 1.15,
-                }
-            ],
-        },
-        {
-            "filename": "aktienpraemiendividende_no_eventType.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Glencore",
-            "isin": "JE00B4T3BW64",
-            "value": 3,
-            "taxes": 1.15,
-            "transactions": [
-                {
-                    "Datum": "2025-09-22T11:20:31",
-                    "Typ": "Dividende",
-                    "Wert": 3.0,
-                    "Notiz": "Glencore",
-                    "ISIN": "JE00B4T3BW64",
-                    "Steuern": 1.15,
-                }
-            ],
-        },
-        {
-            "filename": "aktiensplit.json",
-            "event_type": PPEventType.SPLIT,
-            "title": "Chipotle Mexican Grill",
-            "isin": "US1696561059",
-            "shares": 49,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2024-06-26T08:06:40",
-                    "Typ": "Split",
-                    "Wert": 0,
-                    "Notiz": "Chipotle Mexican Grill",
-                    "ISIN": "US1696561059",
-                    "Stück": 49,
-                }
-            ],
-        },
-        {
-            "filename": "aktiensplit_no_eventType.json",
-            "event_type": PPEventType.SPLIT,
-            "title": "Netflix",
-            "isin": "US64110L1061",
-            "shares": 2.743902,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-11-17T06:07:56",
-                    "Typ": "Split",
-                    "Wert": 0,
-                    "Notiz": "Netflix",
-                    "ISIN": "US64110L1061",
-                    "Stück": 2.743902,
-                }
-            ],
-        },
-        {
-            "filename": "bardividende.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Comcast (A)",
-            "isin": "US20030N1019",
-            "shares": 10.640298,
-            "value": 2.24,
-            "taxes": 0.78,
-            "transactions": [
-                {
-                    "Datum": "2025-10-23T14:19:56",
-                    "Typ": "Dividende",
-                    "Wert": 2.24,
-                    "Notiz": "Comcast (A)",
-                    "ISIN": "US20030N1019",
-                    "Stück": 10.640298,
-                    "Steuern": 0.78,
-                }
-            ],
-        },
-        {
-            "filename": "bardividende_no_eventType.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Lowe's",
-            "isin": "US5486611073",
-            "shares": 1.189904,
-            "value": 0.92,
-            "taxes": 0.32,
-            "transactions": [
-                {
-                    "Datum": "2025-11-05T18:31:19",
-                    "Typ": "Dividende",
-                    "Wert": 0.92,
-                    "Notiz": "Lowe's",
-                    "ISIN": "US5486611073",
-                    "Stück": 1.189904,
-                    "Steuern": 0.32,
-                }
-            ],
-        },
-        {
-            "filename": "bardividende_zero.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "L'Oreal",
-            "isin": "FR0000120321",
-            "shares": 0.000125,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-05-07T15:32:27",
-                    "Typ": "Dividende",
-                    "Wert": 0.0,
-                    "Notiz": "L'Oreal",
-                    "ISIN": "FR0000120321",
-                    "Stück": 0.000125,
-                }
-            ],
-        },
-        {
-            "filename": "bardividende_korrigiert.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Medical Properties Trust",
-            "isin": "US58463J3041",
-            "shares": 40,
-            "value": 4.01,
-            "taxes": 1.53,
-            "transactions": [
-                {
-                    "Datum": "2025-03-20T15:04:31",
-                    "Typ": "Dividende",
-                    "Wert": 4.01,
-                    "Notiz": "Medical Properties Trust",
-                    "ISIN": "US58463J3041",
-                    "Stück": 40.0,
-                    "Steuern": 1.53,
-                }
-            ],
-        },
-        {
-            "filename": "bardividende_korrigiert_no_eventType.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Medical Properties Trust",
-            "isin": "US58463J3041",
-            "shares": 40,
-            "value": 4.01,
-            "taxes": 1.53,
-            "transactions": [
-                {
-                    "Datum": "2025-03-20T15:04:31",
-                    "Typ": "Dividende",
-                    "Wert": 4.01,
-                    "Notiz": "Medical Properties Trust",
-                    "ISIN": "US58463J3041",
-                    "Stück": 40.0,
-                    "Steuern": 1.53,
-                }
-            ],
-        },
-        {
-            "filename": "benefits_spare_change_execution.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "SuperDividend USD (Dist)",
-            "isin": "IE00077FRP95",
-            "shares": 0.383219,
-            "value": -3.38,
-            "transactions": [
-                {
-                    "Datum": "2024-10-02T15:05:40",
-                    "Typ": "Kauf",
-                    "Wert": -3.38,
-                    "Notiz": "SuperDividend USD (Dist)",
-                    "ISIN": "IE00077FRP95",
-                    "Stück": 0.383219,
-                }
-            ],
-        },
-        {
-            "filename": "benefits_spare_change_execution_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "SuperDividend USD (Dist)",
-            "isin": "IE00077FRP95",
-            "shares": 0.383219,
-            "value": -3.38,
-            "transactions": [
-                {
-                    "Datum": "2024-10-02T15:05:40",
-                    "Typ": "Kauf",
-                    "Wert": -3.38,
-                    "Notiz": "SuperDividend USD (Dist)",
-                    "ISIN": "IE00077FRP95",
-                    "Stück": 0.383219,
-                }
-            ],
-        },
-        {
-            "filename": "bonusaktien.json",
-            "event_type": PPEventType.SPLIT,
-            "title": "Eckert & Ziegler",
-            "isin": "DE0005659700",
-            "shares": 5.706536,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-08-15T08:10:12",
-                    "Typ": "Split",
-                    "Wert": 0,
-                    "Notiz": "Eckert & Ziegler",
-                    "ISIN": "DE0005659700",
-                    "Stück": 5.706536,
-                }
-            ],
-        },
-        {
-            "filename": "bonusaktien_no_eventType.json",
-            "event_type": PPEventType.SPLIT,
-            "title": "Eckert & Ziegler",
-            "isin": "DE0005659700",
-            "shares": 5.706536,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-08-15T08:10:12",
-                    "Typ": "Split",
-                    "Wert": 0,
-                    "Notiz": "Eckert & Ziegler",
-                    "ISIN": "DE0005659700",
-                    "Stück": 5.706536,
-                }
-            ],
-        },
-        {
-            "filename": "bonusaktien_tax_only.json",
-            "event_type": PPEventType.TAXES,
-            "title": "BYD",
-            "isin": "CNE100000296",
-            "value": -8.67,
-            "taxes": 8.67,
-            "transactions": [
-                {
-                    "Datum": "2025-08-15T14:53:09",
-                    "Typ": "Steuern",
-                    "Wert": -8.67,
-                    "Notiz": "BYD",
-                    "ISIN": "CNE100000296",
-                    "Steuern": 8.67,
-                }
-            ],
-        },
-        {
-            "filename": "bonusaktien2.json",
-            "event_type": PPEventType.SPLIT,
-            "title": "BYD",
-            "isin": "CNE100000296",
-            "shares": 2.149301,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-08-13T05:22:45",
-                    "Typ": "Split",
-                    "Wert": 0,
-                    "Notiz": "BYD",
-                    "ISIN": "CNE100000296",
-                    "Stück": 2.149301,
-                }
-            ],
-        },
-        {
-            "filename": "bonusaktien_canceled.json",
-            "event_type": None,
-            "title": "BYD",
-            "isin": None,
-            "shares": None,
-            "value": None,
-            "transactions": [],
-        },
-        {
-            "filename": "bonusaktien_tax_only_no_eventType.json",
-            "event_type": PPEventType.TAXES,
-            "title": "BYD",
-            "isin": "CNE100000296",
-            "value": -8.67,
-            "taxes": 8.67,
-            "transactions": [
-                {
-                    "Datum": "2025-08-15T14:53:09",
-                    "Typ": "Steuern",
-                    "Wert": -8.67,
-                    "Notiz": "BYD",
-                    "ISIN": "CNE100000296",
-                    "Steuern": 8.67,
-                }
-            ],
-        },
-        {
-            "filename": "bond_kauf.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Juli 2040",
-            "isin": "DE0001135366",
-            "shares": 82.27,
-            "value": -100.99,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2025-07-18T08:04:42",
-                    "Typ": "Kauf",
-                    "Wert": -100.99,
-                    "Notiz": "Juli 2040",
-                    "ISIN": "DE0001135366",
-                    "Stück": 82.27,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "bond_verkauf.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Juli 2040",
-            "isin": "DE0001135366",
-            "shares": 82.27,
-            "value": 98.21,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2026-03-26T06:48:09",
-                    "Typ": "Verkauf",
-                    "Wert": 98.21,
-                    "Notiz": "Juli 2040",
-                    "ISIN": "DE0001135366",
-                    "Stück": 82.27,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Euro Stoxx 50 EUR (Dist)",
-            "isin": "IE00B4K6B022",
-            "shares": 60,
-            "value": -3002.8,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2024-02-20T16:32:07",
-                    "Typ": "Kauf",
-                    "Wert": -3002.8,
-                    "Notiz": "Euro Stoxx 50 EUR (Dist)",
-                    "ISIN": "IE00B4K6B022",
-                    "Stück": 60.0,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Euro Stoxx 50 EUR (Dist)",
-            "isin": "IE00B4K6B022",
-            "shares": 60,
-            "value": -3002.8,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2024-02-20T16:32:07",
-                    "Typ": "Kauf",
-                    "Wert": -3002.8,
-                    "Notiz": "Euro Stoxx 50 EUR (Dist)",
-                    "ISIN": "IE00B4K6B022",
-                    "Stück": 60.0,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy_new.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "NVIDIA",
-            "isin": "US67066G1040",
-            "shares": 0.685102,
-            "value": -111,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2025-10-10T19:29:43",
-                    "Typ": "Kauf",
-                    "Wert": -111,
-                    "Notiz": "NVIDIA",
-                    "ISIN": "US67066G1040",
-                    "Stück": 0.685102,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy_new_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "NVIDIA",
-            "isin": "US67066G1040",
-            "shares": 0.685102,
-            "value": -111,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2025-10-10T19:29:43",
-                    "Typ": "Kauf",
-                    "Wert": -111,
-                    "Notiz": "NVIDIA",
-                    "ISIN": "US67066G1040",
-                    "Stück": 0.685102,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy_new2.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Rocket Lab Corp. Registered Shares DL-,0001",
-            "isin": "US7731211089",
-            "shares": 2,
-            "value": -75.6,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2025-08-01T08:28:01",
-                    "Typ": "Kauf",
-                    "Wert": -75.6,
-                    "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
-                    "ISIN": "US7731211089",
-                    "Stück": 2,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "buy_new2_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Rocket Lab Corp. Registered Shares DL-,0001",
-            "isin": "US7731211089",
-            "shares": 2,
-            "value": -75.6,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2025-08-01T08:28:01",
-                    "Typ": "Kauf",
-                    "Wert": -75.6,
-                    "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
-                    "ISIN": "US7731211089",
-                    "Stück": 2,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "card_refund.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Decathlon",
-            "value": 24.99,
-            "note": "card_refund",
-            "transactions": [
-                {
-                    "Datum": "2025-08-17T07:23:44",
-                    "Typ": "Einlage",
-                    "Wert": 24.99,
-                    "Notiz": "Kartenerstattung - Decathlon",
-                }
-            ],
-        },
-        {
-            "filename": "card_refund_no_eventType.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Decathlon",
-            "value": 24.99,
-            "note": "card_refund",
-            "transactions": [
-                {
-                    "Datum": "2025-08-17T07:23:44",
-                    "Typ": "Einlage",
-                    "Wert": 24.99,
-                    "Notiz": "Kartenerstattung - Decathlon",
-                }
-            ],
-        },
-        {
-            "filename": "deposit.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "My Name",
-            "value": 200,
-            "transactions": [
-                {
-                    "Datum": "2024-06-03T17:07:26",
-                    "Typ": "Einlage",
-                    "Wert": 200.0,
-                    "Notiz": "My Name",
-                }
-            ],
-        },
-        {
-            "filename": "deposit_no_eventType.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "My Name",
-            "value": 200,
-            "transactions": [
-                {
-                    "Datum": "2024-06-03T17:07:26",
-                    "Typ": "Einlage",
-                    "Wert": 200.0,
-                    "Notiz": "My Name",
-                }
-            ],
-        },
-        {
-            "filename": "dividende_old.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "MSCI World USD (Dist)",
-            "isin": "LU0392494562",
-            "shares": 32,
-            "value": 30.21,
-            "taxes": 6.83,
-            "transactions": [
-                {
-                    "Datum": "2024-12-31T23:59:59",
-                    "Typ": "Dividende",
-                    "Wert": 30.21,
-                    "Notiz": "MSCI World USD (Dist)",
-                    "ISIN": "LU0392494562",
-                    "Stück": 32.0,
-                    "Steuern": 6.83,
-                }
-            ],
-        },
-        {
-            "filename": "dividende_wahlweise.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "National Grid",
-            "isin": "GB00BDR05C01",
-            "value": 3.37,
-            "taxes": 1.28,
-            "transactions": [
-                {
-                    "Datum": "2024-07-19T13:28:04",
-                    "Typ": "Dividende",
-                    "Wert": 3.37,
-                    "Notiz": "National Grid",
-                    "ISIN": "GB00BDR05C01",
-                    "Steuern": 1.28,
-                }
-            ],
-        },
-        {
-            "filename": "dividende_wahlweise_no_eventType.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "National Grid",
-            "isin": "GB00BDR05C01",
-            "value": 3.37,
-            "taxes": 1.28,
-            "transactions": [
-                {
-                    "Datum": "2024-07-19T13:28:04",
-                    "Typ": "Dividende",
-                    "Wert": 3.37,
-                    "Notiz": "National Grid",
-                    "ISIN": "GB00BDR05C01",
-                    "Steuern": 1.28,
-                }
-            ],
-        },
-        {
-            "filename": "incoming_transfer.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Klaus Mustermann",
-            "value": 88.04,
-            "transactions": [
-                {
-                    "Datum": "2024-09-02T17:49:12",
-                    "Typ": "Einlage",
-                    "Wert": 88.04,
-                    "Notiz": "Klaus Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "incoming_transfer_no_eventType.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Klaus Mustermann",
-            "value": 88.04,
-            "transactions": [
-                {
-                    "Datum": "2024-09-02T17:49:12",
-                    "Typ": "Einlage",
-                    "Wert": 88.04,
-                    "Notiz": "Klaus Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "incoming_transfer_delegation.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Vorname Nachname",
-            "value": 3000.0,
-            "transactions": [
-                {
-                    "Datum": "2024-09-10T13:18:31",
-                    "Typ": "Einlage",
-                    "Wert": 3000.0,
-                    "Notiz": "Vorname Nachname",
-                }
-            ],
-        },
-        {
-            "filename": "incoming_transfer_delegation_no_eventType.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Vorname Nachname",
-            "value": 3000.0,
-            "transactions": [
-                {
-                    "Datum": "2024-09-10T13:18:31",
-                    "Typ": "Einlage",
-                    "Wert": 3000.0,
-                    "Notiz": "Vorname Nachname",
-                }
-            ],
-        },
-        {
-            "filename": "ipo-spacex.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "SpaceX",
-            "isin": "US84615Q1031",
-            "shares": 0.276891,
-            "value": -33.33,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2026-06-06T04:20:02",
-                    "Typ": "Kauf",
-                    "Wert": -33.33,
-                    "Notiz": "SpaceX",
-                    "ISIN": "US84615Q1031",
-                    "Stück": 0.276891,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "junior_p2p_transfer.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Maria Mueller",
-            "value": -50,
-            "transactions": [
-                {
-                    "Datum": "2025-09-17T19:35:32",
-                    "Typ": "Entnahme",
-                    "Wert": -50.0,
-                    "Notiz": "Maria Mueller",
-                }
-            ],
-        },
-        {
-            "filename": "junior_p2p_transfer_no_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Maria Mueller",
-            "value": -50,
-            "transactions": [
-                {
-                    "Datum": "2025-09-17T19:35:32",
-                    "Typ": "Entnahme",
-                    "Wert": -50.0,
-                    "Notiz": "Maria Mueller",
-                }
-            ],
-        },
-        {
-            "filename": "kartenzahlung.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Coop Pronto",
-            "value": -12.16,
-            "note": "card_successful_transaction",
-            "transactions": [
-                {
-                    "Datum": "2025-10-21T17:30:01",
-                    "Typ": "Entnahme",
-                    "Wert": -12.16,
-                    "Notiz": "Kartentransaktion - Coop Pronto",
-                }
-            ],
-        },
-        {
-            "filename": "kartenzahlung_null_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Coop Pronto",
-            "value": -12.16,
-            "note": "card_successful_transaction",
-            "transactions": [
-                {
-                    "Datum": "2025-10-21T17:30:01",
-                    "Typ": "Entnahme",
-                    "Wert": -12.16,
-                    "Notiz": "Kartentransaktion - Coop Pronto",
-                }
-            ],
-        },
-        {
-            "filename": "kartenzahlung_no_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Baecker",
-            "value": -2,
-            "note": "card_successful_transaction",
-            "transactions": [
-                {
-                    "Datum": "2025-11-05T11:00:07",
-                    "Typ": "Entnahme",
-                    "Wert": -2.0,
-                    "Notiz": "Kartentransaktion - Baecker",
-                }
-            ],
-        },
-        {
-            "filename": "kauforder_abgelehnt.json",
-            "event_type": None,
-        },
-        {
-            "filename": "legacy_verkauforder_neu_abgerechnet.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Marie Brizard Wine and Spirits",
-            "isin": "FR0000060873",
-            "shares": 27,
-            "value": 91.34,
-            "fees": 1,
-            "transactions": [
-                {
-                    "Datum": "2025-02-21T11:14:54",
-                    "Typ": "Verkauf",
-                    "Wert": 91.34,
-                    "Notiz": "Marie Brizard Wine and Spirits",
-                    "ISIN": "FR0000060873",
-                    "Stück": 27.0,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "legacy_verkauforder_neu_abgerechnet_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Marie Brizard Wine and Spirits",
-            "isin": "FR0000060873",
-            "shares": 27,
-            "value": 91.34,
-            "fees": 1,
-            "transactions": [
-                {
-                    "Datum": "2025-02-21T11:14:54",
-                    "Typ": "Verkauf",
-                    "Wert": 91.34,
-                    "Notiz": "Marie Brizard Wine and Spirits",
-                    "ISIN": "FR0000060873",
-                    "Stück": 27.0,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "legacy_zinsen.json",
-            "event_type": PPEventType.INTEREST,
-            "title": "Zinsen",
-            "value": 11.76,
-            "taxes": 4.51,
-            "transactions": [
-                {
-                    "Datum": "2024-09-01T16:39:48",
-                    "Typ": "Zinsen",
-                    "Wert": 11.76,
-                    "Notiz": "Zinsen",
-                    "Steuern": 4.51,
-                }
-            ],
-        },
-        {
-            "filename": "legacy_zinsen_no_eventType.json",
-            "event_type": PPEventType.INTEREST,
-            "title": "Zinsen",
-            "value": 11.76,
-            "taxes": 4.51,
-            "transactions": [
-                {
-                    "Datum": "2024-09-01T16:39:48",
-                    "Typ": "Zinsen",
-                    "Wert": 11.76,
-                    "Notiz": "Zinsen",
-                    "Steuern": 4.51,
-                }
-            ],
-        },
-        {
-            "filename": "limit-sell-order.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "D-Wave Quantum",
-            "isin": "US26740W1099",
-            "shares": 11,
-            "value": 114.91,
-            "fees": 1,
-            "taxes": 17.36,
-            "transactions": [
-                {
-                    "Datum": "2025-05-20T08:03:45",
-                    "Typ": "Verkauf",
-                    "Wert": 114.91,
-                    "Notiz": "D-Wave Quantum",
-                    "ISIN": "US26740W1099",
-                    "Stück": 11.0,
-                    "Gebühren": 1.0,
-                    "Steuern": 17.36,
-                }
-            ],
-        },
-        {
-            "filename": "limit-sell-order_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Teva Pharmaceutical Industries (ADR)",
-            "isin": "US8816242098",
-            "shares": 8,
-            "value": 139.74,
-            "fees": 1,
-            "taxes": 7.66,
-            "transactions": [
-                {
-                    "Datum": "2025-11-05T12:03:19",
-                    "Typ": "Verkauf",
-                    "Wert": 139.74,
-                    "Notiz": "Teva Pharmaceutical Industries (ADR)",
-                    "ISIN": "US8816242098",
-                    "Stück": 8.0,
-                    "Gebühren": 1.0,
-                    "Steuern": 7.66,
-                }
-            ],
-        },
-        {
-            "filename": "limit-sell-order_old.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Daimler Truck Holding",
-            "isin": "DE000DTR0CK8",
-            "shares": 3,
-            "value": 119.37,
-            "fees": 1,
-            "taxes": 0.14,
-            "transactions": [
-                {
-                    "Datum": "2025-05-14T07:01:32",
-                    "Typ": "Verkauf",
-                    "Wert": 119.37,
-                    "Notiz": "Daimler Truck Holding",
-                    "ISIN": "DE000DTR0CK8",
-                    "Stück": 3.0,
-                    "Gebühren": 1.0,
-                    "Steuern": 0.14,
-                }
-            ],
-        },
-        {
-            "filename": "limit-sell-order_old_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Daimler Truck Holding",
-            "isin": "DE000DTR0CK8",
-            "shares": 3,
-            "value": 119.37,
-            "fees": 1,
-            "taxes": 0.14,
-            "transactions": [
-                {
-                    "Datum": "2025-05-14T07:01:32",
-                    "Typ": "Verkauf",
-                    "Wert": 119.37,
-                    "Notiz": "Daimler Truck Holding",
-                    "ISIN": "DE000DTR0CK8",
-                    "Stück": 3.0,
-                    "Gebühren": 1.0,
-                    "Steuern": 0.14,
-                }
-            ],
-        },
-        {
-            "filename": "neues_geraet.json",
-            "event_type": None,
-        },
-        {
-            "filename": "outgoing_transfer.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Hans Mustermann",
-            "value": -50.3,
-            "transactions": [
-                {
-                    "Datum": "2024-07-21T09:35:47",
-                    "Typ": "Entnahme",
-                    "Wert": -50.3,
-                    "Notiz": "Hans Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "outgoing_transfer_no_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Hans Mustermann",
-            "value": -50.3,
-            "transactions": [
-                {
-                    "Datum": "2024-07-21T09:35:47",
-                    "Typ": "Entnahme",
-                    "Wert": -50.3,
-                    "Notiz": "Hans Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "outgoing_transfer_delegation.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Nina",
-            "value": -67,
-            "transactions": [
-                {
-                    "Datum": "2025-08-18T12:16:06",
-                    "Typ": "Entnahme",
-                    "Wert": -67.0,
-                    "Notiz": "Nina",
-                }
-            ],
-        },
-        {
-            "filename": "outgoing_transfer_delegation_no_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Nina",
-            "value": -67,
-            "transactions": [
-                {
-                    "Datum": "2025-08-18T12:16:06",
-                    "Typ": "Entnahme",
-                    "Wert": -67.0,
-                    "Notiz": "Nina",
-                }
-            ],
-        },
-        {
-            "filename": "outgoing_transfer_legacy.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "My Name",
-            "value": -750,
-            "transactions": [
-                {
-                    "Datum": "2025-04-11T06:44:43",
-                    "Typ": "Entnahme",
-                    "Wert": -750.0,
-                    "Notiz": "My Name",
-                }
-            ],
-        },
-        {
-            "filename": "outgoing_transfer_legacy_no_eventType.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "My Name",
-            "value": -750,
-            "transactions": [
-                {
-                    "Datum": "2025-04-11T06:44:43",
-                    "Typ": "Entnahme",
-                    "Wert": -750.0,
-                    "Notiz": "My Name",
-                }
-            ],
-        },
-        {
-            "filename": "transfer_out.json",
-            "event_type": PPEventType.TRANSFER_OUT,
-            "title": "Novo-Nordisk (B)",
-            "isin": "DK0062498333",
-            "shares": 42.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T17:03:45",
-                    "Typ": "Umbuchung (Ausgang)",
-                    "Wert": 0,
-                    "Notiz": "Novo-Nordisk (B)",
-                    "ISIN": "DK0062498333",
-                    "Stück": 42.0,
-                }
-            ],
-        },
-        {
-            "filename": "transfer_in.json",
-            "event_type": PPEventType.TRANSFER_IN,
-            "title": "British American Tobacco",
-            "isin": "GB0002875804",
-            "shares": 1.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2024-06-14T16:40:07",
-                    "Typ": "Umbuchung (Eingang)",
-                    "Wert": 0,
-                    "Notiz": "British American Tobacco",
-                    "ISIN": "GB0002875804",
-                    "Stück": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "wertpapiertransfer_in.json",
-            "event_type": PPEventType.TRANSFER_IN,
-            "title": "Metro",
-            "isin": "DE000BFB0019",
-            "shares": 76.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2023-06-13T20:38:45",
-                    "Typ": "Umbuchung (Eingang)",
-                    "Wert": 0,
-                    "Notiz": "Metro",
-                    "ISIN": "DE000BFB0019",
-                    "Stück": 76.0,
-                }
-            ],
-        },
-        {
-            "filename": "wertpapiertransfer_out.json",
-            "event_type": PPEventType.TRANSFER_OUT,
-            "title": "Netflix",
-            "isin": "US64110L1061",
-            "shares": 4.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2024-03-15T14:22:33",
-                    "Typ": "Umbuchung (Ausgang)",
-                    "Wert": 0,
-                    "Notiz": "Netflix",
-                    "ISIN": "US64110L1061",
-                    "Stück": 4.0,
-                }
-            ],
-        },
-        {
-            "filename": "wertpapiertransfer_in_legacy.json",
-            "event_type": PPEventType.TRANSFER_IN,
-            "title": "Metro",
-            "isin": "DE000BFB0019",
-            "shares": 76.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2022-04-10T10:15:30",
-                    "Typ": "Umbuchung (Eingang)",
-                    "Wert": 0,
-                    "Notiz": "Metro",
-                    "ISIN": "DE000BFB0019",
-                    "Stück": 76.0,
-                }
-            ],
-        },
-        {
-            "filename": "wertpapiertransfer_out_legacy.json",
-            "event_type": PPEventType.TRANSFER_OUT,
-            "title": "Netflix",
-            "isin": "US64110L1061",
-            "shares": 4.0,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2022-05-20T16:45:00",
-                    "Typ": "Umbuchung (Ausgang)",
-                    "Wert": 0,
-                    "Notiz": "Netflix",
-                    "ISIN": "US64110L1061",
-                    "Stück": 4.0,
-                }
-            ],
-        },
-        {
-            "filename": "transfer_out_cancelled.json",
-            "event_type": None,
-            "title": "MSCI World USD (Dist)",
-            "isin": None,
-            "shares": None,
-            "value": None,
-            "transactions": [],
-        },
-        {
-            "filename": "payment_inbound_credit_card.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Einzahlung",
-            "value": 1000,
-            "fees": 7,
-            "transactions": [
-                {
-                    "Datum": "2022-08-27T05:06:30",
-                    "Typ": "Einlage",
-                    "Wert": 1000.0,
-                    "Notiz": "Einzahlung",
-                    "Gebühren": 7.0,
-                }
-            ],
-        },
-        {
-            "filename": "payment_inbound_credit_card_no_eventType.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Einzahlung",
-            "value": 1000,
-            "fees": 7,
-            "transactions": [
-                {
-                    "Datum": "2022-08-27T05:06:30",
-                    "Typ": "Einlage",
-                    "Wert": 1000.0,
-                    "Notiz": "Einzahlung",
-                    "Gebühren": 7.0,
-                }
-            ],
-        },
-        {
-            "filename": "private_markets_order.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "shares": 1,
-            "value": -101,
-            "fees": 1,
-            "note": "EQT",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Kauf",
-                    "Wert": -101.0,
-                    "Notiz": "EQT - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Stück": 1.0,
-                    "Gebühren": 1.0,
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_order_no_eventType.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "shares": 1,
-            "value": -101,
-            "fees": 1,
-            "note": "EQT",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Kauf",
-                    "Wert": -101.0,
-                    "Notiz": "EQT - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Stück": 1.0,
-                    "Gebühren": 1.0,
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_order_bonus.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "shares": 0.01,
-            "value": -1,
-            "note": "1 % Bonus",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Kauf",
-                    "Wert": -1.0,
-                    "Notiz": "1 % Bonus - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Stück": 0.01,
-                },
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Einlage",
-                    "Wert": 1.0,
-                    "Notiz": "1 % Bonus - Private Equity",
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_order_bonus_no_eventType.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "shares": 0.01,
-            "value": -1,
-            "note": "1 % Bonus",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Kauf",
-                    "Wert": -1.0,
-                    "Notiz": "1 % Bonus - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Stück": 0.01,
-                },
-                {
-                    "Datum": "2025-09-18T07:15:25",
-                    "Typ": "Einlage",
-                    "Wert": 1.0,
-                    "Notiz": "1 % Bonus - Private Equity",
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_trade.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3170240538",
-            "shares": 1,
-            "value": -101,
-            "fees": 1,
-            "note": "Apollo",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Kauf",
-                    "Wert": -101.0,
-                    "Notiz": "Apollo - Private Equity",
-                    "ISIN": "LU3170240538",
-                    "Stück": 1.0,
-                    "Gebühren": 1.0,
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_trade_no_eventType.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3170240538",
-            "shares": 1,
-            "value": -101,
-            "fees": 1,
-            "note": "Apollo",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Kauf",
-                    "Wert": -101.0,
-                    "Notiz": "Apollo - Private Equity",
-                    "ISIN": "LU3170240538",
-                    "Stück": 1.0,
-                    "Gebühren": 1.0,
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_trade_bonus.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "isin": "LU3170240538",
-            "title": "Private Equity",
-            "shares": 0.01,
-            "value": -1,
-            "note": "1 % Bonus",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Kauf",
-                    "Wert": -1,
-                    "Notiz": "1 % Bonus - Private Equity",
-                    "ISIN": "LU3170240538",
-                    "Stück": 0.01,
-                },
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Einlage",
-                    "Wert": 1,
-                    "Notiz": "1 % Bonus - Private Equity",
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_trade_bonus_no_eventType.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "isin": "LU3170240538",
-            "title": "Private Equity",
-            "shares": 0.01,
-            "value": -1,
-            "note": "1 % Bonus",
-            "transactions": [
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Kauf",
-                    "Wert": -1,
-                    "Notiz": "1 % Bonus - Private Equity",
-                    "ISIN": "LU3170240538",
-                    "Stück": 0.01,
-                },
-                {
-                    "Datum": "2025-09-18T07:14:56",
-                    "Typ": "Einlage",
-                    "Wert": 1,
-                    "Notiz": "1 % Bonus - Private Equity",
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_verkaufsorder_erstellt.json",
-        },
-        {
-            "filename": "private_markets_verkaufsorder.json",
-            "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "shares": 1.01,
-            "value": 103.54,
-            "fees": 1,
-            "taxes": 1.24,
-            "note": "EQT",
-            "transactions": [
-                {
-                    "Datum": "2026-06-08T14:15:00",
-                    "Typ": "Verkauf",
-                    "Wert": 103.54,
-                    "Notiz": "EQT - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Stück": 1.01,
-                    "Gebühren": 1.0,
-                    "Steuern": 1.24,
-                },
-            ],
-        },
-        {
-            "filename": "private_markets_vorabpauschale.json",
-            "event_type": PPEventType.TAXES,
-            "title": "Private Equity",
-            "isin": "LU3176111881",
-            "value": -0.07,
-            "taxes": 0.07,
-            "note": "EQT",
-            "transactions": [
-                {
-                    "Datum": "2026-03-09T07:56:12",
-                    "Typ": "Steuern",
-                    "Wert": -0.07,
-                    "Notiz": "EQT - Private Equity",
-                    "ISIN": "LU3176111881",
-                    "Steuern": 0.07,
-                }
-            ],
-        },
-        {
-            "filename": "reverse_split.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Globalstar",
-            "isin": "US3789734080",
-            "isin2": "US3789735079",
-            "shares": 110.403067,
-            "shares2": 7.360204,
-            "value": 0,
-            "note": "GLOBALSTAR INC. O.N.",
-            "transactions": [
-                {
-                    "Datum": "2025-02-11T08:13:48",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Globalstar",
-                    "ISIN": "US3789734080",
-                    "Stück": 110.403067,
-                    "ISIN2": "US3789735079",
-                    "Stück2": 7.360204,
-                },
-            ],
-        },
-        {
-            "filename": "reverse_split_no_eventType.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Globalstar",
-            "isin": "US3789734080",
-            "isin2": "US3789735079",
-            "shares": 110.403067,
-            "shares2": 7.360204,
-            "value": 0,
-            "note": "GLOBALSTAR INC. O.N.",
-            "transactions": [
-                {
-                    "Datum": "2025-02-11T08:13:48",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Globalstar",
-                    "ISIN": "US3789734080",
-                    "Stück": 110.403067,
-                    "ISIN2": "US3789735079",
-                    "Stück2": 7.360204,
-                },
-            ],
-        },
-        {
-            "filename": "reverse_split2.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Honeywell International",
-            "isin": "US4385161066",
-            "isin2": "US4385162056",
-            "shares": 0.966682,
-            "shares2": 0.483341,
-            "value": 0,
-            "note": "Honeywell International",
-            "transactions": [
-                {
-                    "Datum": "2026-06-30T16:46:52",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Honeywell International",
-                    "ISIN": "US4385161066",
-                    "Stück": 0.966682,
-                    "ISIN2": "US4385162056",
-                    "Stück2": 0.483341,
-                },
-            ],
-        },
-        {
-            "filename": "reverse_split3.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Honeywell International",
-            "isin": "US4385161066",
-            "isin2": "US4385161066",
-            "shares": 0.966682,
-            "shares2": 0.483341,
-            "value": 0,
-            "note": "Honeywell International",
-            "transactions": [
-                {
-                    "Datum": "2026-06-30T16:46:52",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Honeywell International",
-                    "ISIN": "US4385161066",
-                    "Stück": 0.966682,
-                    "ISIN2": "US4385161066",
-                    "Stück2": 0.483341,
-                },
-            ],
-        },
-        {
-            "filename": "saveback.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "S&P 500 Information Tech USD (Acc)",
-            "isin": "IE00B3WJKG14",
-            "shares": 0.546348,
-            "value": -15,
-            "transactions": [
-                {
-                    "Datum": "2025-04-02T13:54:23",
-                    "Typ": "Kauf",
-                    "Wert": -15.0,
-                    "Notiz": "S&P 500 Information Tech USD (Acc)",
-                    "ISIN": "IE00B3WJKG14",
-                    "Stück": 0.546348,
-                },
-                {
-                    "Datum": "2025-04-02T13:54:23",
-                    "Typ": "Einlage",
-                    "Wert": 15.0,
-                    "Notiz": "S&P 500 Information Tech USD (Acc)",
-                },
-            ],
-        },
-        {
-            "filename": "saveback_no_eventType.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "Lockheed Martin",
-            "isin": "US5398301094",
-            "shares": 0.035252,
-            "value": -15,
-            "transactions": [
-                {
-                    "Datum": "2025-11-03T15:30:22",
-                    "Typ": "Kauf",
-                    "Wert": -15.0,
-                    "Notiz": "Lockheed Martin",
-                    "ISIN": "US5398301094",
-                    "Stück": 0.035252,
-                },
-                {
-                    "Datum": "2025-11-03T15:30:22",
-                    "Typ": "Einlage",
-                    "Wert": 15.0,
-                    "Notiz": "Lockheed Martin",
-                },
-            ],
-        },
-        {
-            "filename": "savingsplan.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "DroneShield",
-            "isin": "AU000000DRO2",
-            "shares": 6.921675,
-            "value": -19,
-            "transactions": [
-                {
-                    "Datum": "2025-10-23T08:26:13",
-                    "Typ": "Kauf",
-                    "Wert": -19.0,
-                    "Notiz": "DroneShield",
-                    "ISIN": "AU000000DRO2",
-                    "Stück": 6.921675,
-                }
-            ],
-        },
-        {
-            "filename": "savingsplan_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "TSMC (ADR)",
-            "isin": "US8740391003",
-            "shares": 0.037523,
-            "value": -10,
-            "transactions": [
-                {
-                    "Datum": "2025-11-03T15:58:11",
-                    "Typ": "Kauf",
-                    "Wert": -10.0,
-                    "Notiz": "TSMC (ADR)",
-                    "ISIN": "US8740391003",
-                    "Stück": 0.037523,
-                }
-            ],
-        },
-        {
-            "filename": "securities_transfer_incoming.json",
-            "event_type": PPEventType.TRANSFER_IN,
-            "title": "MSCI EM USD (Acc)",
-            "isin": "IE00BTJRMP35",
-            "shares": 7,
-            "value": 0,
-            "transactions": [
-                {
-                    "Datum": "2025-10-13T12:43:03",
-                    "Typ": "Umbuchung (Eingang)",
-                    "Wert": 0,
-                    "Notiz": "MSCI EM USD (Acc)",
-                    "ISIN": "IE00BTJRMP35",
-                    "Stück": 7.0,
-                }
-            ],
-        },
-        {
-            "filename": "sell_stop.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "D-Wave Quantum",
-            "isin": "US26740W1099",
-            "shares": 17,
-            "value": 94.76,
-            "fees": 1,
-            "taxes": 3.18,
-            "transactions": [
-                {
-                    "Datum": "2025-03-14T07:03:14",
-                    "Typ": "Verkauf",
-                    "Wert": 94.76,
-                    "Notiz": "D-Wave Quantum",
-                    "ISIN": "US26740W1099",
-                    "Gebühren": 1.0,
-                    "Steuern": 3.18,
-                    "Stück": 17.0,
-                }
-            ],
-        },
-        {
-            "filename": "sell_stop_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "D-Wave Quantum",
-            "isin": "US26740W1099",
-            "shares": 17,
-            "value": 94.76,
-            "fees": 1,
-            "taxes": 3.18,
-            "transactions": [
-                {
-                    "Datum": "2025-03-14T07:03:14",
-                    "Typ": "Verkauf",
-                    "Wert": 94.76,
-                    "Notiz": "D-Wave Quantum",
-                    "ISIN": "US26740W1099",
-                    "Gebühren": 1.0,
-                    "Steuern": 3.18,
-                    "Stück": 17.0,
-                }
-            ],
-        },
-        {
-            "filename": "spinoff.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "ThyssenKrupp",
-            "isin": "DE000TKMS001",
-            "isin2": "DE0007500001",
-            "shares": 0.309986,
-            "value": 0,
-            "note": "TKMS",
-            "transactions": [
-                {
-                    "Datum": "2025-10-20T11:25:29",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "TKMS",
-                    "ISIN": "DE000TKMS001",
-                    "Stück": 0.309986,
-                    "ISIN2": "DE0007500001",
-                }
-            ],
-        },
-        {
-            "filename": "spinoff_no_eventType.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "ThyssenKrupp",
-            "isin": "DE000TKMS001",
-            "isin2": "DE0007500001",
-            "shares": 0.309986,
-            "value": 0,
-            "note": "TKMS",
-            "transactions": [
-                {
-                    "Datum": "2025-10-20T11:25:29",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "TKMS",
-                    "ISIN": "DE000TKMS001",
-                    "Stück": 0.309986,
-                    "ISIN2": "DE0007500001",
-                }
-            ],
-        },
-        {
-            "filename": "spinoff_only_taxes.json",
-            "event_type": PPEventType.TAXES,
-            "title": "Gamestop Corp. WTS 30.10.26",
-            "isin": "US36467W1172",
-            "value": -0.56,
-            "taxes": 0.56,
-            "transactions": [
-                {
-                    "Datum": "2025-12-19T15:24:37",
-                    "Typ": "Steuern",
-                    "Wert": -0.56,
-                    "Notiz": "Gamestop Corp. WTS 30.10.26",
-                    "ISIN": "US36467W1172",
-                    "Steuern": 0.56,
-                }
-            ],
-        },
-        {
-            "filename": "steuerkorrektur.json",
-            "event_type": PPEventType.TAX_REFUND,
-            "title": "Steuerkorrektur",
-            "value": 2.87,
-            "transactions": [
-                {
-                    "Datum": "2025-10-28T00:00:16",
-                    "Typ": "Steuerrückerstattung",
-                    "Wert": 2.87,
-                    "Notiz": "Steuerkorrektur",
-                }
-            ],
-        },
-        {
-            "filename": "steuerkorrektur_no_eventType.json",
-            "event_type": PPEventType.TAX_REFUND,
-            "title": "Steuerkorrektur",
-            "value": 0.76,
-            "transactions": [
-                {
-                    "Datum": "2025-11-04T23:31:58",
-                    "Typ": "Steuerrückerstattung",
-                    "Wert": 0.76,
-                    "Notiz": "Steuerkorrektur",
-                }
-            ],
-        },
-        {
-            "filename": "tausch_no_eventType.json",
-            "title": "L'Oreal",
-        },
-        {
-            "filename": "teilrueckzahlung.json",
-            "event_type": PPEventType.SWAP,
-            "title": "ORSTED A/S EM.09/25 DK 10",
-            "isin": "DK0064307755",
-            "isin2": "DK0060094928",
-            "shares": 17,
-            "shares2": 17,
-            "value": 0,
-            "note": "Orsted",
-            "transactions": [
-                {
-                    "Datum": "2025-10-23T14:46:49",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S EM.09/25 DK 10",
-                    "ISIN": "DK0064307755",
-                    "Stück": 17.0,
-                    "ISIN2": "DK0060094928",
-                    "Stück2": 17.0,
-                },
-            ],
-        },
-        {
-            "filename": "teilrueckzahlung_no_eventType.json",
-            "event_type": PPEventType.SWAP,
-            "title": "ORSTED A/S EM.09/25 DK 10",
-            "isin": "DK0064307755",
-            "isin2": "DK0060094928",
-            "shares": 17,
-            "shares2": 17,
-            "value": 0,
-            "note": "Orsted",
-            "transactions": [
-                {
-                    "Datum": "2025-10-23T14:46:49",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S EM.09/25 DK 10",
-                    "ISIN": "DK0064307755",
-                    "Stück": 17.0,
-                    "ISIN2": "DK0060094928",
-                    "Stück2": 17.0,
-                },
-            ],
-        },
-        {
-            "filename": "tilgung.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Long 1,2345 $",
-            "isin": "DE000SX12345",
-            "shares": 100,
-            "value": 0.1,
-            "transactions": [
-                {
-                    "Datum": "2025-01-10T10:00:00",
-                    "Typ": "Dividende",
-                    "Wert": 0.1,
-                    "Notiz": "Long 1,2345 $",
-                    "ISIN": "DE000SX12345",
-                    "Stück": 100.0,
-                }
-            ],
-        },
-        {
-            "filename": "tilgung_no_eventType.json",
-            "event_type": PPEventType.DIVIDEND,
-            "title": "Long 1,2345 $",
-            "isin": "DE000SX12345",
-            "shares": 100,
-            "value": 0.1,
-            "transactions": [
-                {
-                    "Datum": "2025-01-10T10:00:00",
-                    "Typ": "Dividende",
-                    "Wert": 0.1,
-                    "Notiz": "Long 1,2345 $",
-                    "ISIN": "DE000SX12345",
-                    "Stück": 100.0,
-                }
-            ],
-        },
-        {
-            "filename": "trade_perk.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "Aktien-Bonus",
-            "isin": "US0378331005",
-            "shares": 0.0487,
-            "value": -10.03,
-            "transactions": [
-                {
-                    "Datum": "2025-04-01T14:09:45",
-                    "Typ": "Kauf",
-                    "Wert": -10.03,
-                    "Notiz": "Aktien-Bonus",
-                    "ISIN": "US0378331005",
-                    "Stück": 0.0487,
-                },
-                {
-                    "Datum": "2025-04-01T14:09:45",
-                    "Typ": "Einlage",
-                    "Wert": 10.03,
-                    "Notiz": "Aktien-Bonus",
-                },
-            ],
-        },
-        {
-            "filename": "trade_perk_no_eventType.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "Aktien-Bonus",
-            "isin": "US0378331005",
-            "shares": 0.0487,
-            "value": -10.03,
-            "transactions": [
-                {
-                    "Datum": "2025-04-01T14:09:45",
-                    "Typ": "Kauf",
-                    "Wert": -10.03,
-                    "Notiz": "Aktien-Bonus",
-                    "ISIN": "US0378331005",
-                    "Stück": 0.0487,
-                },
-                {
-                    "Datum": "2025-04-01T14:09:45",
-                    "Typ": "Einlage",
-                    "Wert": 10.03,
-                    "Notiz": "Aktien-Bonus",
-                },
-            ],
-        },
-        {
-            "filename": "verkaufsorder.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Tencent Holdings (ADR)",
-            "isin": "US88032Q1094",
-            "shares": 3.454506,
-            "value": 200.93,
-            "fees": 1,
-            "taxes": 0.16,
-            "transactions": [
-                {
-                    "Datum": "2025-05-12T18:38:36",
-                    "Typ": "Verkauf",
-                    "Wert": 200.93,
-                    "Notiz": "Tencent Holdings (ADR)",
-                    "ISIN": "US88032Q1094",
-                    "Stück": 3.454506,
-                    "Gebühren": 1.0,
-                    "Steuern": 0.16,
-                }
-            ],
-        },
-        {
-            "filename": "verkaufsorder_no_eventType.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Home Depot",
-            "isin": "US4370761029",
-            "shares": 0.305182,
-            "value": 100,
-            "fees": 1,
-            "transactions": [
-                {
-                    "Datum": "2025-11-04T16:27:25",
-                    "Typ": "Verkauf",
-                    "Wert": 100.0,
-                    "Notiz": "Home Depot",
-                    "ISIN": "US4370761029",
-                    "Stück": 0.305182,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "vorabpauschale.json",
-            "event_type": PPEventType.TAXES,
-            "title": "MSCI China USD (Acc)",
-            "isin": "IE00BJ5JPG56",
-            "value": -0.19,
-            "taxes": 0.19,
-            "transactions": [
-                {
-                    "Datum": "2025-01-28T14:54:28",
-                    "Typ": "Steuern",
-                    "Wert": -0.19,
-                    "Notiz": "MSCI China USD (Acc)",
-                    "ISIN": "IE00BJ5JPG56",
-                    "Steuern": 0.19,
-                }
-            ],
-        },
-        {
-            "filename": "vorabpauschale_no_eventType.json",
-            "event_type": PPEventType.TAXES,
-            "title": "MSCI China USD (Acc)",
-            "isin": "IE00BJ5JPG56",
-            "value": -0.19,
-            "taxes": 0.19,
-            "transactions": [
-                {
-                    "Datum": "2025-01-28T14:54:28",
-                    "Typ": "Steuern",
-                    "Wert": -0.19,
-                    "Notiz": "MSCI China USD (Acc)",
-                    "ISIN": "IE00BJ5JPG56",
-                    "Steuern": 0.19,
-                }
-            ],
-        },
-        {
-            "filename": "zinsen.json",
-            "event_type": PPEventType.INTEREST,
-            "title": "Zinsen",
-            "value": 4.87,
-            "taxes": 1.87,
-            "transactions": [
-                {
-                    "Datum": "2025-07-01T06:46:37",
-                    "Typ": "Zinsen",
-                    "Wert": 4.87,
-                    "Notiz": "Zinsen",
-                    "Steuern": 1.87,
-                }
-            ],
-        },
-        {
-            "filename": "zinsen_no_eventType.json",
-            "event_type": PPEventType.INTEREST,
-            "title": "Zinsen",
-            "value": 4.87,
-            "taxes": 1.87,
-            "transactions": [
-                {
-                    "Datum": "2025-07-01T06:46:37",
-                    "Typ": "Zinsen",
-                    "Wert": 4.87,
-                    "Notiz": "Zinsen",
-                    "Steuern": 1.87,
-                }
-            ],
-        },
-        {
-            "filename": "zusammenschluss.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Rocket Lab USA",
-            "isin": "US7731221062",
-            "isin2": "US7731211089",
-            "shares": 5.943100,
-            "shares2": 5.943100,
-            "value": 0,
-            "note": "ROCKET LAB CORP. O.N.",
-            "transactions": [
-                {
-                    "Datum": "2025-05-29T13:04:58",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Rocket Lab USA",
-                    "ISIN": "US7731221062",
-                    "Stück": 5.9431,
-                    "ISIN2": "US7731211089",
-                    "Stück2": 5.9431,
-                },
-            ],
-        },
-        {
-            "filename": "zusammenschluss_no_eventType.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Rocket Lab USA",
-            "isin": "US7731221062",
-            "isin2": "US7731211089",
-            "shares": 5.943100,
-            "shares2": 5.943100,
-            "value": 0,
-            "note": "ROCKET LAB CORP. O.N.",
-            "transactions": [
-                {
-                    "Datum": "2025-05-29T13:04:58",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Rocket Lab USA",
-                    "ISIN": "US7731221062",
-                    "Stück": 5.9431,
-                    "ISIN2": "US7731211089",
-                    "Stück2": 5.9431,
-                },
-            ],
-        },
-        {
-            "filename": "zusammenschluss2.json",
-            "event_type": PPEventType.SWAP,
-            "title": "Rocket Lab USA",
-            "isin": "US7731221062",
-            "isin2": "US7731211089",
-            "shares": 5.943100,
-            "shares2": 5.943100,
-            "value": 0,
-            "note": "ROCKET LAB CORP. O.N.",
-            "transactions": [
-                {
-                    "Datum": "2025-05-29T13:04:58",
-                    "Typ": "Swap",
-                    "Wert": 0,
-                    "Notiz": "Rocket Lab USA",
-                    "ISIN": "US7731221062",
-                    "Stück": 5.9431,
-                    "ISIN2": "US7731211089",
-                    "Stück2": 5.9431,
-                },
-            ],
-        },
-        {
-            "filename": "zwischenpapiere.json",
-            "event_type": PPEventType.SWAP,
-            "title": "ORSTED A/S   -ANR-",
-            "isin": "DK0064307839",
-            "isin2": "DK0064307755",
-            "shares": 119,
-            "shares2": 17,
-            "value": -151.59,
-            "note": "ORSTED A/S EM.09/25 DK 10",
-            "transactions": [
-                {
-                    "Datum": "2025-10-21T07:39:39",
-                    "Typ": "Swap",
-                    "Wert": -151.59,
-                    "ISIN": "DK0064307839",
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "Stück": 119.0,
-                    "ISIN2": "DK0064307755",
-                    "Stück2": 17.0,
-                },
-            ],
-        },
-        {
-            "filename": "zwischenpapiere2.json",
-            "event_type": PPEventType.SWAP,
-            "title": "WORLDLINE S.A. ANR",
-            "isin": "FR0014015MS9",
-            "isin2": "FR0011981968",
-            "shares": 1,
-            "shares2": 6,
-            "value": -1.21,
-            "note": "Worldline",
-            "transactions": [
-                {
-                    "Datum": "2026-04-03T09:37:06",
-                    "Typ": "Swap",
-                    "Wert": -1.21,
-                    "ISIN": "FR0014015MS9",
-                    "Notiz": "WORLDLINE S.A. ANR",
-                    "Stück": 1.0,
-                    "ISIN2": "FR0011981968",
-                    "Stück2": 6.0,
-                },
-            ],
-        },
-        {
-            "filename": "zwischenpapiere3.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Worldline",
-            "isin": "FR0011981968",
-            "shares": 1294,
-            "value": -261.39,
-            "transactions": [
-                {
-                    "Datum": "2026-04-03T10:38:58",
-                    "Typ": "Kauf",
-                    "Wert": -261.39,
-                    "ISIN": "FR0011981968",
-                    "Notiz": "Worldline",
-                    "Stück": 1294.0,
-                },
-            ],
-        },
-        {
-            "filename": "zwischenpapiere_no_eventType.json",
-            "event_type": PPEventType.SWAP,
-            "title": "ORSTED A/S   -ANR-",
-            "isin": "DK0064307839",
-            "isin2": "DK0064307755",
-            "shares": 119,
-            "shares2": 17,
-            "value": -151.59,
-            "note": "ORSTED A/S EM.09/25 DK 10",
-            "transactions": [
-                {
-                    "Datum": "2025-10-21T07:39:39",
-                    "Typ": "Swap",
-                    "Wert": -151.59,
-                    "ISIN": "DK0064307839",
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "Stück": 119.0,
-                    "ISIN2": "DK0064307755",
-                    "Stück2": 17.0,
-                },
-            ],
-        },
-        {
-            "filename": "zwischenvertrieb.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "Orsted",
-            "isin": "DK0064307839",
-            "isin2": "DK0060094928",
-            "shares": 119.285835,
-            "value": 0,
-            "note": "ORSTED A/S   -ANR-",
-            "transactions": [
-                {
-                    "Datum": "2025-09-19T12:02:49",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "ISIN": "DK0064307839",
-                    "Stück": 119.285835,
-                    "ISIN2": "DK0060094928",
-                }
-            ],
-        },
-        {
-            "filename": "zwischenvertrieb_no_eventType.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "Orsted",
-            "isin": "DK0064307839",
-            "isin2": "DK0060094928",
-            "shares": 119.285835,
-            "value": 0,
-            "note": "ORSTED A/S   -ANR-",
-            "transactions": [
-                {
-                    "Datum": "2025-09-19T12:02:49",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "ORSTED A/S   -ANR-",
-                    "ISIN": "DK0064307839",
-                    "Stück": 119.285835,
-                    "ISIN2": "DK0060094928",
-                }
-            ],
-        },
-        {
-            "filename": "zwischenvertrieb2.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "Worldline",
-            "isin": "FR0014015MS9",
-            "isin2": "FR0011981968",
-            "shares": 1.299376,
-            "value": 0,
-            "note": "Worldline",
-            "transactions": [
-                {
-                    "Datum": "2026-03-17T10:45:33",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "Worldline",
-                    "ISIN": "FR0014015MS9",
-                    "Stück": 1.299376,
-                    "ISIN2": "FR0011981968",
-                }
-            ],
-        },
-        {
-            "filename": "zwischenvertrieb3.json",
-            "event_type": PPEventType.SPINOFF,
-            "title": "OHB",
-            "isin": "DE000A41YFG5",
-            "isin2": "DE0005936124",
-            "shares": 1.026415,
-            "value": 0,
-            "note": "OHB",
-            "transactions": [
-                {
-                    "Datum": "2026-06-29T09:09:14",
-                    "Typ": "Spinoff",
-                    "Wert": 0,
-                    "Notiz": "OHB",
-                    "ISIN": "DE000A41YFG5",
-                    "Stück": 1.026415,
-                    "ISIN2": "DE0005936124",
-                }
-            ],
-        },
-        {
-            "filename": "bank_transaction_incoming.json",
-            "event_type": PPEventType.DEPOSIT,
-            "title": "Max Mustermann",
-            "value": 5.15,
-            "transactions": [
-                {
-                    "Datum": "2024-07-04T06:17:41",
-                    "Typ": "Einlage",
-                    "Wert": 5.15,
-                    "Notiz": "Max Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "bank_transaction_outgoing.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "Max Mustermann",
-            "value": -50.3,
-            "transactions": [
-                {
-                    "Datum": "2024-07-21T09:35:47",
-                    "Typ": "Entnahme",
-                    "Wert": -50.3,
-                    "Notiz": "Max Mustermann",
-                }
-            ],
-        },
-        {
-            "filename": "card_transaction.json",
-            "event_type": PPEventType.REMOVAL,
-            "title": "REWE",
-            "value": -4.28,
-            "note": "card_successful_transaction",
-            "transactions": [
-                {
-                    "Datum": "2024-06-03T15:10:48",
-                    "Typ": "Entnahme",
-                    "Wert": -4.28,
-                    "Notiz": "Kartentransaktion - REWE",
-                }
-            ],
-        },
-        {
-            "filename": "interest_payout_created.json",
-            "event_type": PPEventType.INTEREST,
-            "title": "Zinsen",
-            "value": 13.56,
-            "taxes": 5.21,
-            "transactions": [
-                {
-                    "Datum": "2024-07-01T04:51:32",
-                    "Typ": "Zinsen",
-                    "Wert": 13.56,
-                    "Notiz": "Zinsen",
-                    "Steuern": 5.21,
-                }
-            ],
-        },
-        {
-            "filename": "saveback_aggregate.json",
-            "event_type": ConditionalEventType.SAVEBACK,
-            "title": "S&P 500 Information Tech USD (Acc)",
-            "isin": "IE00B3WJKG14",
-            "value": -15.0,
-            "shares": 0.501924,
-            "transactions": [
-                {
-                    "Datum": "2024-07-02T13:53:44",
-                    "Typ": "Kauf",
-                    "Wert": -15.0,
-                    "Notiz": "S&P 500 Information Tech USD (Acc)",
-                    "ISIN": "IE00B3WJKG14",
-                    "Stück": 0.501924,
-                },
-                {
-                    "Datum": "2024-07-02T13:53:44",
-                    "Typ": "Einlage",
-                    "Wert": 15.0,
-                    "Notiz": "S&P 500 Information Tech USD (Acc)",
-                },
-            ],
-        },
-        {
-            "filename": "savings_plan_invoice_created.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Volkswagen (Vz.)",
-            "isin": "DE0007664039",
-            "value": -1.0,
-            "shares": 0.00961,
-            "transactions": [
-                {
-                    "Datum": "2024-06-17T08:16:25",
-                    "Typ": "Kauf",
-                    "Wert": -1.0,
-                    "Notiz": "Volkswagen (Vz.)",
-                    "ISIN": "DE0007664039",
-                    "Stück": 0.00961,
-                }
-            ],
-        },
-        {
-            "filename": "spare_change_aggregate.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "S&P 500 Information Tech USD (Acc)",
-            "isin": "IE00B3WJKG14",
-            "value": -5.81,
-            "shares": 0.208318,
-            "transactions": [
-                {
-                    "Datum": "2024-06-10T13:52:18",
-                    "Typ": "Kauf",
-                    "Wert": -5.81,
-                    "Notiz": "S&P 500 Information Tech USD (Acc)",
-                    "ISIN": "IE00B3WJKG14",
-                    "Stück": 0.208318,
-                }
-            ],
-        },
-        {
-            "filename": "ssp_tax_correction.json",
-            "event_type": PPEventType.TAX_REFUND,
-            "title": "Steuerkorrektur",
-            "value": 3.47,
-            "transactions": [
-                {
-                    "Datum": "2024-06-11T22:45:15",
-                    "Typ": "Steuerrückerstattung",
-                    "Wert": 3.47,
-                    "Notiz": "Steuerkorrektur",
-                }
-            ],
-        },
-        {
-            "filename": "trade_corrected.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "Worldline",
-            "isin": "FR0011981968",
-            "value": 105.85,
-            "shares": 13.0,
-            "fees": 1.0,
-            "taxes": 1.8,
-            "transactions": [
-                {
-                    "Datum": "2024-12-16T09:59:01",
-                    "Typ": "Verkauf",
-                    "Wert": 105.85,
-                    "Notiz": "Worldline",
-                    "ISIN": "FR0011981968",
-                    "Stück": 13.0,
-                    "Gebühren": 1.0,
-                    "Steuern": 1.8,
-                }
-            ],
-        },
-        {
-            "filename": "trade_invoice.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "DWS Group",
-            "isin": "DE000DWS1007",
-            "value": -221.0,
-            "shares": 5.0,
-            "fees": 1.0,
-            "transactions": [
-                {
-                    "Datum": "2024-06-04T06:23:45",
-                    "Typ": "Kauf",
-                    "Wert": -221.0,
-                    "Notiz": "DWS Group",
-                    "ISIN": "DE000DWS1007",
-                    "Stück": 5.0,
-                    "Gebühren": 1.0,
-                }
-            ],
-        },
-        {
-            "filename": "trading_savingsplan_executed.json",
-            "event_type": ConditionalEventType.TRADE_INVOICE,
-            "title": "BASF",
-            "isin": "DE000BASF111",
-            "value": -15.0,
-            "shares": 0.316355,
-            "transactions": [
-                {
-                    "Datum": "2025-02-10T09:23:13",
-                    "Typ": "Kauf",
-                    "Wert": -15.0,
-                    "Notiz": "BASF",
-                    "ISIN": "DE000BASF111",
-                    "Stück": 0.316355,
-                }
-            ],
-        },
-    ]
+test_data: list[dict] = [
+    {
+        "filename": "address_changed.json",
+        "event_type": None,
+    },
+    {
+        "filename": "aktien_entfernt.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "ORSTED A/S   -ANR-",
+        "isin": "DK0064307839",
+        "shares": 0.285835,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-10-28T15:46:46",
+                "Typ": "Verkauf",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S   -ANR-",
+                "ISIN": "DK0064307839",
+                "Stück": 0.285835,
+            }
+        ],
+    },
+    {
+        "filename": "aktien_entfernt_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "ORSTED A/S   -ANR-",
+        "isin": "DK0064307839",
+        "shares": 0.285835,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-10-28T15:46:46",
+                "Typ": "Verkauf",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S   -ANR-",
+                "ISIN": "DK0064307839",
+                "Stück": 0.285835,
+            }
+        ],
+    },
+    {
+        "filename": "aktien_entfernt2.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "WORLDLINE S.A. ANR",
+        "isin": "FR0014015MS9",
+        "shares": 0.299376,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2026-04-03T10:48:40",
+                "Typ": "Verkauf",
+                "Wert": 0,
+                "Notiz": "WORLDLINE S.A. ANR",
+                "ISIN": "FR0014015MS9",
+                "Stück": 0.299376,
+            }
+        ],
+    },
+    {
+        "filename": "aktienbonus.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "Aktien-Bonus",
+        "isin": "US2546871060",
+        "shares": 0.105,
+        "value": -10.03,
+        "transactions": [
+            {
+                "Datum": "2025-10-13T14:49:06",
+                "Typ": "Kauf",
+                "Wert": -10.03,
+                "Notiz": "Aktien-Bonus",
+                "ISIN": "US2546871060",
+                "Stück": 0.105,
+            },
+            {
+                "Datum": "2025-10-13T14:49:06",
+                "Typ": "Einlage",
+                "Wert": 10.03,
+                "Notiz": "Aktien-Bonus",
+            },
+        ],
+    },
+    {
+        "filename": "aktienbonus_no_eventType.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "Aktien-Bonus",
+        "isin": "US2546871060",
+        "shares": 0.105,
+        "value": -10.03,
+        "transactions": [
+            {
+                "Datum": "2025-10-13T14:49:06",
+                "Typ": "Kauf",
+                "Wert": -10.03,
+                "Notiz": "Aktien-Bonus",
+                "ISIN": "US2546871060",
+                "Stück": 0.105,
+            },
+            {
+                "Datum": "2025-10-13T14:49:06",
+                "Typ": "Einlage",
+                "Wert": 10.03,
+                "Notiz": "Aktien-Bonus",
+            },
+        ],
+    },
+    {
+        "filename": "aktiendividende.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "Enovix",
+        "isin": "US2935941318",
+        "isin2": "US2935941078",
+        "shares": 0.494370,
+        "value": 0,
+        "note": "Enovix Corp. WTS 01.10.26",
+        "transactions": [
+            {
+                "Datum": "2025-07-22T14:31:49",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "Enovix Corp. WTS 01.10.26",
+                "ISIN": "US2935941318",
+                "Stück": 0.494370,
+                "ISIN2": "US2935941078",
+            }
+        ],
+    },
+    {
+        "filename": "aktiendividende_no_eventType.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "Enovix",
+        "isin": "US2935941318",
+        "isin2": "US2935941078",
+        "shares": 0.494370,
+        "value": 0,
+        "note": "Enovix Corp. WTS 01.10.26",
+        "transactions": [
+            {
+                "Datum": "2025-07-22T14:31:49",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "Enovix Corp. WTS 01.10.26",
+                "ISIN": "US2935941318",
+                "Stück": 0.494370,
+                "ISIN2": "US2935941078",
+            }
+        ],
+    },
+    {
+        "filename": "aktiendividende_only_taxes.json",
+        "event_type": PPEventType.TAXES,
+        "title": "Enovix Corp. WTS 01.10.26",
+        "isin": "US2935941318",
+        "value": -0.57,
+        "taxes": 0.57,
+        "transactions": [
+            {
+                "Datum": "2026-01-06T16:14:51",
+                "Typ": "Steuern",
+                "Wert": -0.57,
+                "Notiz": "Enovix Corp. WTS 01.10.26",
+                "ISIN": "US2935941318",
+                "Steuern": 0.57,
+            }
+        ],
+    },
+    {
+        "filename": "aktienpraemiendividende.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Glencore",
+        "isin": "JE00B4T3BW64",
+        "value": 3,
+        "taxes": 1.15,
+        "transactions": [
+            {
+                "Datum": "2025-09-22T11:20:31",
+                "Typ": "Dividende",
+                "Wert": 3.0,
+                "Notiz": "Glencore",
+                "ISIN": "JE00B4T3BW64",
+                "Steuern": 1.15,
+            }
+        ],
+    },
+    {
+        "filename": "aktienpraemiendividende2.json",
+        "event_type": None,
+    },
+    {
+        "filename": "aktienpraemiendividende_no_eventType.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Glencore",
+        "isin": "JE00B4T3BW64",
+        "value": 3,
+        "taxes": 1.15,
+        "transactions": [
+            {
+                "Datum": "2025-09-22T11:20:31",
+                "Typ": "Dividende",
+                "Wert": 3.0,
+                "Notiz": "Glencore",
+                "ISIN": "JE00B4T3BW64",
+                "Steuern": 1.15,
+            }
+        ],
+    },
+    {
+        "filename": "aktiensplit.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "Chipotle Mexican Grill",
+        "isin": "US1696561059",
+        "shares": 49,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2024-06-26T08:06:40",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "Chipotle Mexican Grill",
+                "ISIN": "US1696561059",
+                "Stück": 49,
+            }
+        ],
+    },
+    {
+        "filename": "aktiensplit2.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "Crowdstrike Holdings (A)",
+        "isin": "US22788C1053",
+        "shares": 0.688026,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2026-07-02T06:31:26",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "Crowdstrike Holdings (A)",
+                "ISIN": "US22788C1053",
+                "Stück": 0.688026,
+            }
+        ],
+    },
+    {
+        "filename": "aktiensplit_no_eventType.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "Netflix",
+        "isin": "US64110L1061",
+        "shares": 2.743902,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-11-17T06:07:56",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "Netflix",
+                "ISIN": "US64110L1061",
+                "Stück": 2.743902,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Comcast (A)",
+        "isin": "US20030N1019",
+        "shares": 10.640298,
+        "value": 2.24,
+        "taxes": 0.78,
+        "transactions": [
+            {
+                "Datum": "2025-10-23T14:19:56",
+                "Typ": "Dividende",
+                "Wert": 2.24,
+                "Notiz": "Comcast (A)",
+                "ISIN": "US20030N1019",
+                "Stück": 10.640298,
+                "Steuern": 0.78,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende_no_eventType.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Lowe's",
+        "isin": "US5486611073",
+        "shares": 1.189904,
+        "value": 0.92,
+        "taxes": 0.32,
+        "transactions": [
+            {
+                "Datum": "2025-11-05T18:31:19",
+                "Typ": "Dividende",
+                "Wert": 0.92,
+                "Notiz": "Lowe's",
+                "ISIN": "US5486611073",
+                "Stück": 1.189904,
+                "Steuern": 0.32,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende_zero.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "L'Oreal",
+        "isin": "FR0000120321",
+        "shares": 0.000125,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-05-07T15:32:27",
+                "Typ": "Dividende",
+                "Wert": 0.0,
+                "Notiz": "L'Oreal",
+                "ISIN": "FR0000120321",
+                "Stück": 0.000125,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende_korrigiert.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Medical Properties Trust",
+        "isin": "US58463J3041",
+        "shares": 40,
+        "value": 4.01,
+        "taxes": 1.53,
+        "transactions": [
+            {
+                "Datum": "2025-03-20T15:04:31",
+                "Typ": "Dividende",
+                "Wert": 4.01,
+                "Notiz": "Medical Properties Trust",
+                "ISIN": "US58463J3041",
+                "Stück": 40.0,
+                "Steuern": 1.53,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende_korrigiert_no_eventType.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Medical Properties Trust",
+        "isin": "US58463J3041",
+        "shares": 40,
+        "value": 4.01,
+        "taxes": 1.53,
+        "transactions": [
+            {
+                "Datum": "2025-03-20T15:04:31",
+                "Typ": "Dividende",
+                "Wert": 4.01,
+                "Notiz": "Medical Properties Trust",
+                "ISIN": "US58463J3041",
+                "Stück": 40.0,
+                "Steuern": 1.53,
+            }
+        ],
+    },
+    {
+        "filename": "bardividende_korrigiert2.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Medical Properties Trust",
+        "isin": "US58463J3041",
+        "value": 0.37,
+        "transactions": [
+            {
+                "Datum": "2026-06-26T13:51:37",
+                "Typ": "Dividende",
+                "Wert": 0.37,
+                "Notiz": "Medical Properties Trust",
+                "ISIN": "US58463J3041",
+            }
+        ],
+    },
+    {
+        "filename": "benefits_spare_change_execution.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "SuperDividend USD (Dist)",
+        "isin": "IE00077FRP95",
+        "shares": 0.383219,
+        "value": -3.38,
+        "transactions": [
+            {
+                "Datum": "2024-10-02T15:05:40",
+                "Typ": "Kauf",
+                "Wert": -3.38,
+                "Notiz": "SuperDividend USD (Dist)",
+                "ISIN": "IE00077FRP95",
+                "Stück": 0.383219,
+            }
+        ],
+    },
+    {
+        "filename": "benefits_spare_change_execution_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "SuperDividend USD (Dist)",
+        "isin": "IE00077FRP95",
+        "shares": 0.383219,
+        "value": -3.38,
+        "transactions": [
+            {
+                "Datum": "2024-10-02T15:05:40",
+                "Typ": "Kauf",
+                "Wert": -3.38,
+                "Notiz": "SuperDividend USD (Dist)",
+                "ISIN": "IE00077FRP95",
+                "Stück": 0.383219,
+            }
+        ],
+    },
+    {
+        "filename": "bonusaktien.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "Eckert & Ziegler",
+        "isin": "DE0005659700",
+        "shares": 5.706536,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-08-15T08:10:12",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "Eckert & Ziegler",
+                "ISIN": "DE0005659700",
+                "Stück": 5.706536,
+            }
+        ],
+    },
+    {
+        "filename": "bonusaktien_no_eventType.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "Eckert & Ziegler",
+        "isin": "DE0005659700",
+        "shares": 5.706536,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-08-15T08:10:12",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "Eckert & Ziegler",
+                "ISIN": "DE0005659700",
+                "Stück": 5.706536,
+            }
+        ],
+    },
+    {
+        "filename": "bonusaktien_tax_only.json",
+        "event_type": PPEventType.TAXES,
+        "title": "BYD",
+        "isin": "CNE100000296",
+        "value": -8.67,
+        "taxes": 8.67,
+        "transactions": [
+            {
+                "Datum": "2025-08-15T14:53:09",
+                "Typ": "Steuern",
+                "Wert": -8.67,
+                "Notiz": "BYD",
+                "ISIN": "CNE100000296",
+                "Steuern": 8.67,
+            }
+        ],
+    },
+    {
+        "filename": "bonusaktien2.json",
+        "event_type": PPEventType.SPLIT,
+        "title": "BYD",
+        "isin": "CNE100000296",
+        "shares": 2.149301,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-08-13T05:22:45",
+                "Typ": "Split",
+                "Wert": 0,
+                "Notiz": "BYD",
+                "ISIN": "CNE100000296",
+                "Stück": 2.149301,
+            }
+        ],
+    },
+    {
+        "filename": "bonusaktien_canceled.json",
+        "event_type": None,
+        "title": "BYD",
+        "isin": None,
+        "shares": None,
+        "value": None,
+        "transactions": [],
+    },
+    {
+        "filename": "bonusaktien_tax_only_no_eventType.json",
+        "event_type": PPEventType.TAXES,
+        "title": "BYD",
+        "isin": "CNE100000296",
+        "value": -8.67,
+        "taxes": 8.67,
+        "transactions": [
+            {
+                "Datum": "2025-08-15T14:53:09",
+                "Typ": "Steuern",
+                "Wert": -8.67,
+                "Notiz": "BYD",
+                "ISIN": "CNE100000296",
+                "Steuern": 8.67,
+            }
+        ],
+    },
+    {
+        "filename": "bond_kauf.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Juli 2040",
+        "isin": "DE0001135366",
+        "shares": 82.27,
+        "value": -100.99,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2025-07-18T08:04:42",
+                "Typ": "Kauf",
+                "Wert": -100.99,
+                "Notiz": "Juli 2040",
+                "ISIN": "DE0001135366",
+                "Stück": 82.27,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "bond_verkauf.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Juli 2040",
+        "isin": "DE0001135366",
+        "shares": 82.27,
+        "value": 98.21,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2026-03-26T06:48:09",
+                "Typ": "Verkauf",
+                "Wert": 98.21,
+                "Notiz": "Juli 2040",
+                "ISIN": "DE0001135366",
+                "Stück": 82.27,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Euro Stoxx 50 EUR (Dist)",
+        "isin": "IE00B4K6B022",
+        "shares": 60,
+        "value": -3002.8,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2024-02-20T16:32:07",
+                "Typ": "Kauf",
+                "Wert": -3002.8,
+                "Notiz": "Euro Stoxx 50 EUR (Dist)",
+                "ISIN": "IE00B4K6B022",
+                "Stück": 60.0,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Euro Stoxx 50 EUR (Dist)",
+        "isin": "IE00B4K6B022",
+        "shares": 60,
+        "value": -3002.8,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2024-02-20T16:32:07",
+                "Typ": "Kauf",
+                "Wert": -3002.8,
+                "Notiz": "Euro Stoxx 50 EUR (Dist)",
+                "ISIN": "IE00B4K6B022",
+                "Stück": 60.0,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy_new.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "NVIDIA",
+        "isin": "US67066G1040",
+        "shares": 0.685102,
+        "value": -111,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2025-10-10T19:29:43",
+                "Typ": "Kauf",
+                "Wert": -111,
+                "Notiz": "NVIDIA",
+                "ISIN": "US67066G1040",
+                "Stück": 0.685102,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy_new_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "NVIDIA",
+        "isin": "US67066G1040",
+        "shares": 0.685102,
+        "value": -111,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2025-10-10T19:29:43",
+                "Typ": "Kauf",
+                "Wert": -111,
+                "Notiz": "NVIDIA",
+                "ISIN": "US67066G1040",
+                "Stück": 0.685102,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy_new2.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Rocket Lab Corp. Registered Shares DL-,0001",
+        "isin": "US7731211089",
+        "shares": 2,
+        "value": -75.6,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2025-08-01T08:28:01",
+                "Typ": "Kauf",
+                "Wert": -75.6,
+                "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
+                "ISIN": "US7731211089",
+                "Stück": 2,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "buy_new2_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Rocket Lab Corp. Registered Shares DL-,0001",
+        "isin": "US7731211089",
+        "shares": 2,
+        "value": -75.6,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2025-08-01T08:28:01",
+                "Typ": "Kauf",
+                "Wert": -75.6,
+                "Notiz": "Rocket Lab Corp. Registered Shares DL-,0001",
+                "ISIN": "US7731211089",
+                "Stück": 2,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "card_refund.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Decathlon",
+        "value": 24.99,
+        "note": "card_refund",
+        "transactions": [
+            {
+                "Datum": "2025-08-17T07:23:44",
+                "Typ": "Einlage",
+                "Wert": 24.99,
+                "Notiz": "Kartenerstattung - Decathlon",
+            }
+        ],
+    },
+    {
+        "filename": "card_refund_no_eventType.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Decathlon",
+        "value": 24.99,
+        "note": "card_refund",
+        "transactions": [
+            {
+                "Datum": "2025-08-17T07:23:44",
+                "Typ": "Einlage",
+                "Wert": 24.99,
+                "Notiz": "Kartenerstattung - Decathlon",
+            }
+        ],
+    },
+    {
+        "filename": "deposit.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "My Name",
+        "value": 200,
+        "transactions": [
+            {
+                "Datum": "2024-06-03T17:07:26",
+                "Typ": "Einlage",
+                "Wert": 200.0,
+                "Notiz": "My Name",
+            }
+        ],
+    },
+    {
+        "filename": "deposit_no_eventType.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "My Name",
+        "value": 200,
+        "transactions": [
+            {
+                "Datum": "2024-06-03T17:07:26",
+                "Typ": "Einlage",
+                "Wert": 200.0,
+                "Notiz": "My Name",
+            }
+        ],
+    },
+    {
+        "filename": "dividende_old.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "MSCI World USD (Dist)",
+        "isin": "LU0392494562",
+        "shares": 32,
+        "value": 30.21,
+        "taxes": 6.83,
+        "transactions": [
+            {
+                "Datum": "2024-12-31T23:59:59",
+                "Typ": "Dividende",
+                "Wert": 30.21,
+                "Notiz": "MSCI World USD (Dist)",
+                "ISIN": "LU0392494562",
+                "Stück": 32.0,
+                "Steuern": 6.83,
+            }
+        ],
+    },
+    {
+        "filename": "dividende_wahlweise.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "National Grid",
+        "isin": "GB00BDR05C01",
+        "value": 3.37,
+        "taxes": 1.28,
+        "transactions": [
+            {
+                "Datum": "2024-07-19T13:28:04",
+                "Typ": "Dividende",
+                "Wert": 3.37,
+                "Notiz": "National Grid",
+                "ISIN": "GB00BDR05C01",
+                "Steuern": 1.28,
+            }
+        ],
+    },
+    {
+        "filename": "dividende_wahlweise_no_eventType.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "National Grid",
+        "isin": "GB00BDR05C01",
+        "value": 3.37,
+        "taxes": 1.28,
+        "transactions": [
+            {
+                "Datum": "2024-07-19T13:28:04",
+                "Typ": "Dividende",
+                "Wert": 3.37,
+                "Notiz": "National Grid",
+                "ISIN": "GB00BDR05C01",
+                "Steuern": 1.28,
+            }
+        ],
+    },
+    {
+        "filename": "dividende_wahlweise2.json",
+        "event_type": None,
+    },
+    {
+        "filename": "dividende_wahlweise3.json",
+        "event_type": None,
+    },
+    {
+        "filename": "incoming_transfer.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Klaus Mustermann",
+        "value": 88.04,
+        "transactions": [
+            {
+                "Datum": "2024-09-02T17:49:12",
+                "Typ": "Einlage",
+                "Wert": 88.04,
+                "Notiz": "Klaus Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "incoming_transfer_no_eventType.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Klaus Mustermann",
+        "value": 88.04,
+        "transactions": [
+            {
+                "Datum": "2024-09-02T17:49:12",
+                "Typ": "Einlage",
+                "Wert": 88.04,
+                "Notiz": "Klaus Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "incoming_transfer_delegation.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Vorname Nachname",
+        "value": 3000.0,
+        "transactions": [
+            {
+                "Datum": "2024-09-10T13:18:31",
+                "Typ": "Einlage",
+                "Wert": 3000.0,
+                "Notiz": "Vorname Nachname",
+            }
+        ],
+    },
+    {
+        "filename": "incoming_transfer_delegation_no_eventType.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Vorname Nachname",
+        "value": 3000.0,
+        "transactions": [
+            {
+                "Datum": "2024-09-10T13:18:31",
+                "Typ": "Einlage",
+                "Wert": 3000.0,
+                "Notiz": "Vorname Nachname",
+            }
+        ],
+    },
+    {
+        "filename": "ipo-spacex.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "SpaceX",
+        "isin": "US84615Q1031",
+        "shares": 0.276891,
+        "value": -33.33,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2026-06-06T04:20:02",
+                "Typ": "Kauf",
+                "Wert": -33.33,
+                "Notiz": "SpaceX",
+                "ISIN": "US84615Q1031",
+                "Stück": 0.276891,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "junior_p2p_transfer.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Maria Mueller",
+        "value": -50,
+        "transactions": [
+            {
+                "Datum": "2025-09-17T19:35:32",
+                "Typ": "Entnahme",
+                "Wert": -50.0,
+                "Notiz": "Maria Mueller",
+            }
+        ],
+    },
+    {
+        "filename": "junior_p2p_transfer_no_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Maria Mueller",
+        "value": -50,
+        "transactions": [
+            {
+                "Datum": "2025-09-17T19:35:32",
+                "Typ": "Entnahme",
+                "Wert": -50.0,
+                "Notiz": "Maria Mueller",
+            }
+        ],
+    },
+    {
+        "filename": "kartenzahlung.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Coop Pronto",
+        "value": -12.16,
+        "note": "card_successful_transaction",
+        "transactions": [
+            {
+                "Datum": "2025-10-21T17:30:01",
+                "Typ": "Entnahme",
+                "Wert": -12.16,
+                "Notiz": "Kartentransaktion - Coop Pronto",
+            }
+        ],
+    },
+    {
+        "filename": "kartenzahlung_null_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Coop Pronto",
+        "value": -12.16,
+        "note": "card_successful_transaction",
+        "transactions": [
+            {
+                "Datum": "2025-10-21T17:30:01",
+                "Typ": "Entnahme",
+                "Wert": -12.16,
+                "Notiz": "Kartentransaktion - Coop Pronto",
+            }
+        ],
+    },
+    {
+        "filename": "kartenzahlung_no_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Baecker",
+        "value": -2,
+        "note": "card_successful_transaction",
+        "transactions": [
+            {
+                "Datum": "2025-11-05T11:00:07",
+                "Typ": "Entnahme",
+                "Wert": -2.0,
+                "Notiz": "Kartentransaktion - Baecker",
+            }
+        ],
+    },
+    {
+        "filename": "kauforder_abgelehnt.json",
+        "event_type": None,
+    },
+    {
+        "filename": "legacy_verkauforder_neu_abgerechnet.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Marie Brizard Wine and Spirits",
+        "isin": "FR0000060873",
+        "shares": 27,
+        "value": 91.34,
+        "fees": 1,
+        "transactions": [
+            {
+                "Datum": "2025-02-21T11:14:54",
+                "Typ": "Verkauf",
+                "Wert": 91.34,
+                "Notiz": "Marie Brizard Wine and Spirits",
+                "ISIN": "FR0000060873",
+                "Stück": 27.0,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "legacy_verkauforder_neu_abgerechnet_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Marie Brizard Wine and Spirits",
+        "isin": "FR0000060873",
+        "shares": 27,
+        "value": 91.34,
+        "fees": 1,
+        "transactions": [
+            {
+                "Datum": "2025-02-21T11:14:54",
+                "Typ": "Verkauf",
+                "Wert": 91.34,
+                "Notiz": "Marie Brizard Wine and Spirits",
+                "ISIN": "FR0000060873",
+                "Stück": 27.0,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "legacy_zinsen.json",
+        "event_type": PPEventType.INTEREST,
+        "title": "Zinsen",
+        "value": 11.76,
+        "taxes": 4.51,
+        "transactions": [
+            {
+                "Datum": "2024-09-01T16:39:48",
+                "Typ": "Zinsen",
+                "Wert": 11.76,
+                "Notiz": "Zinsen",
+                "Steuern": 4.51,
+            }
+        ],
+    },
+    {
+        "filename": "legacy_zinsen_no_eventType.json",
+        "event_type": PPEventType.INTEREST,
+        "title": "Zinsen",
+        "value": 11.76,
+        "taxes": 4.51,
+        "transactions": [
+            {
+                "Datum": "2024-09-01T16:39:48",
+                "Typ": "Zinsen",
+                "Wert": 11.76,
+                "Notiz": "Zinsen",
+                "Steuern": 4.51,
+            }
+        ],
+    },
+    {
+        "filename": "limit-sell-order.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "D-Wave Quantum",
+        "isin": "US26740W1099",
+        "shares": 11,
+        "value": 114.91,
+        "fees": 1,
+        "taxes": 17.36,
+        "transactions": [
+            {
+                "Datum": "2025-05-20T08:03:45",
+                "Typ": "Verkauf",
+                "Wert": 114.91,
+                "Notiz": "D-Wave Quantum",
+                "ISIN": "US26740W1099",
+                "Stück": 11.0,
+                "Gebühren": 1.0,
+                "Steuern": 17.36,
+            }
+        ],
+    },
+    {
+        "filename": "limit-sell-order_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Teva Pharmaceutical Industries (ADR)",
+        "isin": "US8816242098",
+        "shares": 8,
+        "value": 139.74,
+        "fees": 1,
+        "taxes": 7.66,
+        "transactions": [
+            {
+                "Datum": "2025-11-05T12:03:19",
+                "Typ": "Verkauf",
+                "Wert": 139.74,
+                "Notiz": "Teva Pharmaceutical Industries (ADR)",
+                "ISIN": "US8816242098",
+                "Stück": 8.0,
+                "Gebühren": 1.0,
+                "Steuern": 7.66,
+            }
+        ],
+    },
+    {
+        "filename": "limit-sell-order_old.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Daimler Truck Holding",
+        "isin": "DE000DTR0CK8",
+        "shares": 3,
+        "value": 119.37,
+        "fees": 1,
+        "taxes": 0.14,
+        "transactions": [
+            {
+                "Datum": "2025-05-14T07:01:32",
+                "Typ": "Verkauf",
+                "Wert": 119.37,
+                "Notiz": "Daimler Truck Holding",
+                "ISIN": "DE000DTR0CK8",
+                "Stück": 3.0,
+                "Gebühren": 1.0,
+                "Steuern": 0.14,
+            }
+        ],
+    },
+    {
+        "filename": "limit-sell-order_old_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Daimler Truck Holding",
+        "isin": "DE000DTR0CK8",
+        "shares": 3,
+        "value": 119.37,
+        "fees": 1,
+        "taxes": 0.14,
+        "transactions": [
+            {
+                "Datum": "2025-05-14T07:01:32",
+                "Typ": "Verkauf",
+                "Wert": 119.37,
+                "Notiz": "Daimler Truck Holding",
+                "ISIN": "DE000DTR0CK8",
+                "Stück": 3.0,
+                "Gebühren": 1.0,
+                "Steuern": 0.14,
+            }
+        ],
+    },
+    {
+        "filename": "neues_geraet.json",
+        "event_type": None,
+    },
+    {
+        "filename": "outgoing_transfer.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Hans Mustermann",
+        "value": -50.3,
+        "transactions": [
+            {
+                "Datum": "2024-07-21T09:35:47",
+                "Typ": "Entnahme",
+                "Wert": -50.3,
+                "Notiz": "Hans Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "outgoing_transfer_no_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Hans Mustermann",
+        "value": -50.3,
+        "transactions": [
+            {
+                "Datum": "2024-07-21T09:35:47",
+                "Typ": "Entnahme",
+                "Wert": -50.3,
+                "Notiz": "Hans Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "outgoing_transfer_delegation.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Nina",
+        "value": -67,
+        "transactions": [
+            {
+                "Datum": "2025-08-18T12:16:06",
+                "Typ": "Entnahme",
+                "Wert": -67.0,
+                "Notiz": "Nina",
+            }
+        ],
+    },
+    {
+        "filename": "outgoing_transfer_delegation_no_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Nina",
+        "value": -67,
+        "transactions": [
+            {
+                "Datum": "2025-08-18T12:16:06",
+                "Typ": "Entnahme",
+                "Wert": -67.0,
+                "Notiz": "Nina",
+            }
+        ],
+    },
+    {
+        "filename": "outgoing_transfer_legacy.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "My Name",
+        "value": -750,
+        "transactions": [
+            {
+                "Datum": "2025-04-11T06:44:43",
+                "Typ": "Entnahme",
+                "Wert": -750.0,
+                "Notiz": "My Name",
+            }
+        ],
+    },
+    {
+        "filename": "outgoing_transfer_legacy_no_eventType.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "My Name",
+        "value": -750,
+        "transactions": [
+            {
+                "Datum": "2025-04-11T06:44:43",
+                "Typ": "Entnahme",
+                "Wert": -750.0,
+                "Notiz": "My Name",
+            }
+        ],
+    },
+    {
+        "filename": "transfer_out.json",
+        "event_type": PPEventType.TRANSFER_OUT,
+        "title": "Novo-Nordisk (B)",
+        "isin": "DK0062498333",
+        "shares": 42.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-09-18T17:03:45",
+                "Typ": "Umbuchung (Ausgang)",
+                "Wert": 0,
+                "Notiz": "Novo-Nordisk (B)",
+                "ISIN": "DK0062498333",
+                "Stück": 42.0,
+            }
+        ],
+    },
+    {
+        "filename": "transfer_in.json",
+        "event_type": PPEventType.TRANSFER_IN,
+        "title": "British American Tobacco",
+        "isin": "GB0002875804",
+        "shares": 1.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2024-06-14T16:40:07",
+                "Typ": "Umbuchung (Eingang)",
+                "Wert": 0,
+                "Notiz": "British American Tobacco",
+                "ISIN": "GB0002875804",
+                "Stück": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "wertpapiertransfer_in.json",
+        "event_type": PPEventType.TRANSFER_IN,
+        "title": "Metro",
+        "isin": "DE000BFB0019",
+        "shares": 76.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2023-06-13T20:38:45",
+                "Typ": "Umbuchung (Eingang)",
+                "Wert": 0,
+                "Notiz": "Metro",
+                "ISIN": "DE000BFB0019",
+                "Stück": 76.0,
+            }
+        ],
+    },
+    {
+        "filename": "wertpapiertransfer_out.json",
+        "event_type": PPEventType.TRANSFER_OUT,
+        "title": "Netflix",
+        "isin": "US64110L1061",
+        "shares": 4.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2024-03-15T14:22:33",
+                "Typ": "Umbuchung (Ausgang)",
+                "Wert": 0,
+                "Notiz": "Netflix",
+                "ISIN": "US64110L1061",
+                "Stück": 4.0,
+            }
+        ],
+    },
+    {
+        "filename": "wertpapiertransfer_in_legacy.json",
+        "event_type": PPEventType.TRANSFER_IN,
+        "title": "Metro",
+        "isin": "DE000BFB0019",
+        "shares": 76.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2022-04-10T10:15:30",
+                "Typ": "Umbuchung (Eingang)",
+                "Wert": 0,
+                "Notiz": "Metro",
+                "ISIN": "DE000BFB0019",
+                "Stück": 76.0,
+            }
+        ],
+    },
+    {
+        "filename": "wertpapiertransfer_out_legacy.json",
+        "event_type": PPEventType.TRANSFER_OUT,
+        "title": "Netflix",
+        "isin": "US64110L1061",
+        "shares": 4.0,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2022-05-20T16:45:00",
+                "Typ": "Umbuchung (Ausgang)",
+                "Wert": 0,
+                "Notiz": "Netflix",
+                "ISIN": "US64110L1061",
+                "Stück": 4.0,
+            }
+        ],
+    },
+    {
+        "filename": "transfer_out_cancelled.json",
+        "event_type": None,
+        "title": "MSCI World USD (Dist)",
+        "isin": None,
+        "shares": None,
+        "value": None,
+        "transactions": [],
+    },
+    {
+        "filename": "payment_inbound_credit_card.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Einzahlung",
+        "value": 1000,
+        "fees": 7,
+        "transactions": [
+            {
+                "Datum": "2022-08-27T05:06:30",
+                "Typ": "Einlage",
+                "Wert": 1000.0,
+                "Notiz": "Einzahlung",
+                "Gebühren": 7.0,
+            }
+        ],
+    },
+    {
+        "filename": "payment_inbound_credit_card_no_eventType.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Einzahlung",
+        "value": 1000,
+        "fees": 7,
+        "transactions": [
+            {
+                "Datum": "2022-08-27T05:06:30",
+                "Typ": "Einlage",
+                "Wert": 1000.0,
+                "Notiz": "Einzahlung",
+                "Gebühren": 7.0,
+            }
+        ],
+    },
+    {
+        "filename": "private_markets_order.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "shares": 1,
+        "value": -101,
+        "fees": 1,
+        "note": "EQT",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Kauf",
+                "Wert": -101.0,
+                "Notiz": "EQT - Private Equity",
+                "ISIN": "LU3176111881",
+                "Stück": 1.0,
+                "Gebühren": 1.0,
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_order_no_eventType.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "shares": 1,
+        "value": -101,
+        "fees": 1,
+        "note": "EQT",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Kauf",
+                "Wert": -101.0,
+                "Notiz": "EQT - Private Equity",
+                "ISIN": "LU3176111881",
+                "Stück": 1.0,
+                "Gebühren": 1.0,
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_order_bonus.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "shares": 0.01,
+        "value": -1,
+        "note": "1 % Bonus",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Kauf",
+                "Wert": -1.0,
+                "Notiz": "1 % Bonus - Private Equity",
+                "ISIN": "LU3176111881",
+                "Stück": 0.01,
+            },
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Einlage",
+                "Wert": 1.0,
+                "Notiz": "1 % Bonus - Private Equity",
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_order_bonus_no_eventType.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "shares": 0.01,
+        "value": -1,
+        "note": "1 % Bonus",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Kauf",
+                "Wert": -1.0,
+                "Notiz": "1 % Bonus - Private Equity",
+                "ISIN": "LU3176111881",
+                "Stück": 0.01,
+            },
+            {
+                "Datum": "2025-09-18T07:15:25",
+                "Typ": "Einlage",
+                "Wert": 1.0,
+                "Notiz": "1 % Bonus - Private Equity",
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_trade.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3170240538",
+        "shares": 1,
+        "value": -101,
+        "fees": 1,
+        "note": "Apollo",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Kauf",
+                "Wert": -101.0,
+                "Notiz": "Apollo - Private Equity",
+                "ISIN": "LU3170240538",
+                "Stück": 1.0,
+                "Gebühren": 1.0,
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_trade_no_eventType.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3170240538",
+        "shares": 1,
+        "value": -101,
+        "fees": 1,
+        "note": "Apollo",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Kauf",
+                "Wert": -101.0,
+                "Notiz": "Apollo - Private Equity",
+                "ISIN": "LU3170240538",
+                "Stück": 1.0,
+                "Gebühren": 1.0,
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_trade_bonus.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "isin": "LU3170240538",
+        "title": "Private Equity",
+        "shares": 0.01,
+        "value": -1,
+        "note": "1 % Bonus",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Kauf",
+                "Wert": -1,
+                "Notiz": "1 % Bonus - Private Equity",
+                "ISIN": "LU3170240538",
+                "Stück": 0.01,
+            },
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Einlage",
+                "Wert": 1,
+                "Notiz": "1 % Bonus - Private Equity",
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_trade_bonus_no_eventType.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "isin": "LU3170240538",
+        "title": "Private Equity",
+        "shares": 0.01,
+        "value": -1,
+        "note": "1 % Bonus",
+        "transactions": [
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Kauf",
+                "Wert": -1,
+                "Notiz": "1 % Bonus - Private Equity",
+                "ISIN": "LU3170240538",
+                "Stück": 0.01,
+            },
+            {
+                "Datum": "2025-09-18T07:14:56",
+                "Typ": "Einlage",
+                "Wert": 1,
+                "Notiz": "1 % Bonus - Private Equity",
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_verkaufsorder_erstellt.json",
+    },
+    {
+        "filename": "private_markets_verkaufsorder.json",
+        "event_type": ConditionalEventType.PRIVATE_MARKETS_ORDER,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "shares": 1.01,
+        "value": 103.54,
+        "fees": 1,
+        "taxes": 1.24,
+        "note": "EQT",
+        "transactions": [
+            {
+                "Datum": "2026-06-08T14:15:00",
+                "Typ": "Verkauf",
+                "Wert": 103.54,
+                "Notiz": "EQT - Private Equity",
+                "ISIN": "LU3176111881",
+                "Stück": 1.01,
+                "Gebühren": 1.0,
+                "Steuern": 1.24,
+            },
+        ],
+    },
+    {
+        "filename": "private_markets_vorabpauschale.json",
+        "event_type": PPEventType.TAXES,
+        "title": "Private Equity",
+        "isin": "LU3176111881",
+        "value": -0.07,
+        "taxes": 0.07,
+        "note": "EQT",
+        "transactions": [
+            {
+                "Datum": "2026-03-09T07:56:12",
+                "Typ": "Steuern",
+                "Wert": -0.07,
+                "Notiz": "EQT - Private Equity",
+                "ISIN": "LU3176111881",
+                "Steuern": 0.07,
+            }
+        ],
+    },
+    {
+        "filename": "reverse_split.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Globalstar",
+        "isin": "US3789734080",
+        "isin2": "US3789735079",
+        "shares": 110.403067,
+        "shares2": 7.360204,
+        "value": 0,
+        "note": "GLOBALSTAR INC. O.N.",
+        "transactions": [
+            {
+                "Datum": "2025-02-11T08:13:48",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Globalstar",
+                "ISIN": "US3789734080",
+                "Stück": 110.403067,
+                "ISIN2": "US3789735079",
+                "Stück2": 7.360204,
+            },
+        ],
+    },
+    {
+        "filename": "reverse_split_no_eventType.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Globalstar",
+        "isin": "US3789734080",
+        "isin2": "US3789735079",
+        "shares": 110.403067,
+        "shares2": 7.360204,
+        "value": 0,
+        "note": "GLOBALSTAR INC. O.N.",
+        "transactions": [
+            {
+                "Datum": "2025-02-11T08:13:48",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Globalstar",
+                "ISIN": "US3789734080",
+                "Stück": 110.403067,
+                "ISIN2": "US3789735079",
+                "Stück2": 7.360204,
+            },
+        ],
+    },
+    {
+        "filename": "reverse_split2.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Honeywell International",
+        "isin": "US4385161066",
+        "isin2": "US4385162056",
+        "shares": 0.966682,
+        "shares2": 0.483341,
+        "value": 0,
+        "note": "Honeywell International",
+        "transactions": [
+            {
+                "Datum": "2026-06-30T16:46:52",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Honeywell International",
+                "ISIN": "US4385161066",
+                "Stück": 0.966682,
+                "ISIN2": "US4385162056",
+                "Stück2": 0.483341,
+            },
+        ],
+    },
+    {
+        "filename": "reverse_split3.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Honeywell International",
+        "isin": "US4385161066",
+        "isin2": "US4385161066",
+        "shares": 0.966682,
+        "shares2": 0.483341,
+        "value": 0,
+        "note": "Honeywell International",
+        "transactions": [
+            {
+                "Datum": "2026-06-30T16:46:52",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Honeywell International",
+                "ISIN": "US4385161066",
+                "Stück": 0.966682,
+                "ISIN2": "US4385161066",
+                "Stück2": 0.483341,
+            },
+        ],
+    },
+    {
+        "filename": "saveback.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "S&P 500 Information Tech USD (Acc)",
+        "isin": "IE00B3WJKG14",
+        "shares": 0.546348,
+        "value": -15,
+        "transactions": [
+            {
+                "Datum": "2025-04-02T13:54:23",
+                "Typ": "Kauf",
+                "Wert": -15.0,
+                "Notiz": "S&P 500 Information Tech USD (Acc)",
+                "ISIN": "IE00B3WJKG14",
+                "Stück": 0.546348,
+            },
+            {
+                "Datum": "2025-04-02T13:54:23",
+                "Typ": "Einlage",
+                "Wert": 15.0,
+                "Notiz": "S&P 500 Information Tech USD (Acc)",
+            },
+        ],
+    },
+    {
+        "filename": "saveback_no_eventType.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "Lockheed Martin",
+        "isin": "US5398301094",
+        "shares": 0.035252,
+        "value": -15,
+        "transactions": [
+            {
+                "Datum": "2025-11-03T15:30:22",
+                "Typ": "Kauf",
+                "Wert": -15.0,
+                "Notiz": "Lockheed Martin",
+                "ISIN": "US5398301094",
+                "Stück": 0.035252,
+            },
+            {
+                "Datum": "2025-11-03T15:30:22",
+                "Typ": "Einlage",
+                "Wert": 15.0,
+                "Notiz": "Lockheed Martin",
+            },
+        ],
+    },
+    {
+        "filename": "savingsplan.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "DroneShield",
+        "isin": "AU000000DRO2",
+        "shares": 6.921675,
+        "value": -19,
+        "transactions": [
+            {
+                "Datum": "2025-10-23T08:26:13",
+                "Typ": "Kauf",
+                "Wert": -19.0,
+                "Notiz": "DroneShield",
+                "ISIN": "AU000000DRO2",
+                "Stück": 6.921675,
+            }
+        ],
+    },
+    {
+        "filename": "savingsplan_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "TSMC (ADR)",
+        "isin": "US8740391003",
+        "shares": 0.037523,
+        "value": -10,
+        "transactions": [
+            {
+                "Datum": "2025-11-03T15:58:11",
+                "Typ": "Kauf",
+                "Wert": -10.0,
+                "Notiz": "TSMC (ADR)",
+                "ISIN": "US8740391003",
+                "Stück": 0.037523,
+            }
+        ],
+    },
+    {
+        "filename": "securities_transfer_incoming.json",
+        "event_type": PPEventType.TRANSFER_IN,
+        "title": "MSCI EM USD (Acc)",
+        "isin": "IE00BTJRMP35",
+        "shares": 7,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-10-13T12:43:03",
+                "Typ": "Umbuchung (Eingang)",
+                "Wert": 0,
+                "Notiz": "MSCI EM USD (Acc)",
+                "ISIN": "IE00BTJRMP35",
+                "Stück": 7.0,
+            }
+        ],
+    },
+    {
+        "filename": "sell_stop.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "D-Wave Quantum",
+        "isin": "US26740W1099",
+        "shares": 17,
+        "value": 94.76,
+        "fees": 1,
+        "taxes": 3.18,
+        "transactions": [
+            {
+                "Datum": "2025-03-14T07:03:14",
+                "Typ": "Verkauf",
+                "Wert": 94.76,
+                "Notiz": "D-Wave Quantum",
+                "ISIN": "US26740W1099",
+                "Gebühren": 1.0,
+                "Steuern": 3.18,
+                "Stück": 17.0,
+            }
+        ],
+    },
+    {
+        "filename": "sell_stop_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "D-Wave Quantum",
+        "isin": "US26740W1099",
+        "shares": 17,
+        "value": 94.76,
+        "fees": 1,
+        "taxes": 3.18,
+        "transactions": [
+            {
+                "Datum": "2025-03-14T07:03:14",
+                "Typ": "Verkauf",
+                "Wert": 94.76,
+                "Notiz": "D-Wave Quantum",
+                "ISIN": "US26740W1099",
+                "Gebühren": 1.0,
+                "Steuern": 3.18,
+                "Stück": 17.0,
+            }
+        ],
+    },
+    {
+        "filename": "spinoff.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "ThyssenKrupp",
+        "isin": "DE000TKMS001",
+        "isin2": "DE0007500001",
+        "shares": 0.309986,
+        "value": 0,
+        "note": "TKMS",
+        "transactions": [
+            {
+                "Datum": "2025-10-20T11:25:29",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "TKMS",
+                "ISIN": "DE000TKMS001",
+                "Stück": 0.309986,
+                "ISIN2": "DE0007500001",
+            }
+        ],
+    },
+    {
+        "filename": "spinoff_no_eventType.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "ThyssenKrupp",
+        "isin": "DE000TKMS001",
+        "isin2": "DE0007500001",
+        "shares": 0.309986,
+        "value": 0,
+        "note": "TKMS",
+        "transactions": [
+            {
+                "Datum": "2025-10-20T11:25:29",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "TKMS",
+                "ISIN": "DE000TKMS001",
+                "Stück": 0.309986,
+                "ISIN2": "DE0007500001",
+            }
+        ],
+    },
+    {
+        "filename": "spinoff_only_taxes.json",
+        "event_type": PPEventType.TAXES,
+        "title": "Gamestop Corp. WTS 30.10.26",
+        "isin": "US36467W1172",
+        "value": -0.56,
+        "taxes": 0.56,
+        "transactions": [
+            {
+                "Datum": "2025-12-19T15:24:37",
+                "Typ": "Steuern",
+                "Wert": -0.56,
+                "Notiz": "Gamestop Corp. WTS 30.10.26",
+                "ISIN": "US36467W1172",
+                "Steuern": 0.56,
+            }
+        ],
+    },
+    {
+        "filename": "steuerkorrektur.json",
+        "event_type": PPEventType.TAX_REFUND,
+        "title": "Steuerkorrektur",
+        "value": 2.87,
+        "transactions": [
+            {
+                "Datum": "2025-10-28T00:00:16",
+                "Typ": "Steuerrückerstattung",
+                "Wert": 2.87,
+                "Notiz": "Steuerkorrektur",
+            }
+        ],
+    },
+    {
+        "filename": "steuerkorrektur_no_eventType.json",
+        "event_type": PPEventType.TAX_REFUND,
+        "title": "Steuerkorrektur",
+        "value": 0.76,
+        "transactions": [
+            {
+                "Datum": "2025-11-04T23:31:58",
+                "Typ": "Steuerrückerstattung",
+                "Wert": 0.76,
+                "Notiz": "Steuerkorrektur",
+            }
+        ],
+    },
+    {
+        "filename": "tausch_no_eventType.json",
+        "title": "L'Oreal",
+    },
+    {
+        "filename": "teilrueckzahlung.json",
+        "event_type": PPEventType.SWAP,
+        "title": "ORSTED A/S EM.09/25 DK 10",
+        "isin": "DK0064307755",
+        "isin2": "DK0060094928",
+        "shares": 17,
+        "shares2": 17,
+        "value": 0,
+        "note": "Orsted",
+        "transactions": [
+            {
+                "Datum": "2025-10-23T14:46:49",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S EM.09/25 DK 10",
+                "ISIN": "DK0064307755",
+                "Stück": 17.0,
+                "ISIN2": "DK0060094928",
+                "Stück2": 17.0,
+            },
+        ],
+    },
+    {
+        "filename": "teilrueckzahlung_no_eventType.json",
+        "event_type": PPEventType.SWAP,
+        "title": "ORSTED A/S EM.09/25 DK 10",
+        "isin": "DK0064307755",
+        "isin2": "DK0060094928",
+        "shares": 17,
+        "shares2": 17,
+        "value": 0,
+        "note": "Orsted",
+        "transactions": [
+            {
+                "Datum": "2025-10-23T14:46:49",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S EM.09/25 DK 10",
+                "ISIN": "DK0064307755",
+                "Stück": 17.0,
+                "ISIN2": "DK0060094928",
+                "Stück2": 17.0,
+            },
+        ],
+    },
+    {
+        "filename": "tilgung.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Long 1,2345 $",
+        "isin": "DE000SX12345",
+        "shares": 100,
+        "value": 0.1,
+        "transactions": [
+            {
+                "Datum": "2025-01-10T10:00:00",
+                "Typ": "Dividende",
+                "Wert": 0.1,
+                "Notiz": "Long 1,2345 $",
+                "ISIN": "DE000SX12345",
+                "Stück": 100.0,
+            }
+        ],
+    },
+    {
+        "filename": "tilgung_no_eventType.json",
+        "event_type": PPEventType.DIVIDEND,
+        "title": "Long 1,2345 $",
+        "isin": "DE000SX12345",
+        "shares": 100,
+        "value": 0.1,
+        "transactions": [
+            {
+                "Datum": "2025-01-10T10:00:00",
+                "Typ": "Dividende",
+                "Wert": 0.1,
+                "Notiz": "Long 1,2345 $",
+                "ISIN": "DE000SX12345",
+                "Stück": 100.0,
+            }
+        ],
+    },
+    {
+        "filename": "trade_perk.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "Aktien-Bonus",
+        "isin": "US0378331005",
+        "shares": 0.0487,
+        "value": -10.03,
+        "transactions": [
+            {
+                "Datum": "2025-04-01T14:09:45",
+                "Typ": "Kauf",
+                "Wert": -10.03,
+                "Notiz": "Aktien-Bonus",
+                "ISIN": "US0378331005",
+                "Stück": 0.0487,
+            },
+            {
+                "Datum": "2025-04-01T14:09:45",
+                "Typ": "Einlage",
+                "Wert": 10.03,
+                "Notiz": "Aktien-Bonus",
+            },
+        ],
+    },
+    {
+        "filename": "trade_perk_no_eventType.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "Aktien-Bonus",
+        "isin": "US0378331005",
+        "shares": 0.0487,
+        "value": -10.03,
+        "transactions": [
+            {
+                "Datum": "2025-04-01T14:09:45",
+                "Typ": "Kauf",
+                "Wert": -10.03,
+                "Notiz": "Aktien-Bonus",
+                "ISIN": "US0378331005",
+                "Stück": 0.0487,
+            },
+            {
+                "Datum": "2025-04-01T14:09:45",
+                "Typ": "Einlage",
+                "Wert": 10.03,
+                "Notiz": "Aktien-Bonus",
+            },
+        ],
+    },
+    {
+        "filename": "verkaufsorder.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Tencent Holdings (ADR)",
+        "isin": "US88032Q1094",
+        "shares": 3.454506,
+        "value": 200.93,
+        "fees": 1,
+        "taxes": 0.16,
+        "transactions": [
+            {
+                "Datum": "2025-05-12T18:38:36",
+                "Typ": "Verkauf",
+                "Wert": 200.93,
+                "Notiz": "Tencent Holdings (ADR)",
+                "ISIN": "US88032Q1094",
+                "Stück": 3.454506,
+                "Gebühren": 1.0,
+                "Steuern": 0.16,
+            }
+        ],
+    },
+    {
+        "filename": "verkaufsorder_no_eventType.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Home Depot",
+        "isin": "US4370761029",
+        "shares": 0.305182,
+        "value": 100,
+        "fees": 1,
+        "transactions": [
+            {
+                "Datum": "2025-11-04T16:27:25",
+                "Typ": "Verkauf",
+                "Wert": 100.0,
+                "Notiz": "Home Depot",
+                "ISIN": "US4370761029",
+                "Stück": 0.305182,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "verkaufsorder_abrechnung12.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Zalando",
+        "isin": "DE000ZAL1111",
+        "shares": 4.795804,
+        "value": 93.07,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2026-05-18T15:37:40",
+                "Typ": "Verkauf",
+                "Wert": 93.07,
+                "Notiz": "Zalando",
+                "ISIN": "DE000ZAL1111",
+                "Stück": 4.795804,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "vorabpauschale.json",
+        "event_type": PPEventType.TAXES,
+        "title": "MSCI China USD (Acc)",
+        "isin": "IE00BJ5JPG56",
+        "value": -0.19,
+        "taxes": 0.19,
+        "transactions": [
+            {
+                "Datum": "2025-01-28T14:54:28",
+                "Typ": "Steuern",
+                "Wert": -0.19,
+                "Notiz": "MSCI China USD (Acc)",
+                "ISIN": "IE00BJ5JPG56",
+                "Steuern": 0.19,
+            }
+        ],
+    },
+    {
+        "filename": "vorabpauschale_no_eventType.json",
+        "event_type": PPEventType.TAXES,
+        "title": "MSCI China USD (Acc)",
+        "isin": "IE00BJ5JPG56",
+        "value": -0.19,
+        "taxes": 0.19,
+        "transactions": [
+            {
+                "Datum": "2025-01-28T14:54:28",
+                "Typ": "Steuern",
+                "Wert": -0.19,
+                "Notiz": "MSCI China USD (Acc)",
+                "ISIN": "IE00BJ5JPG56",
+                "Steuern": 0.19,
+            }
+        ],
+    },
+    {
+        "filename": "zinsen.json",
+        "event_type": PPEventType.INTEREST,
+        "title": "Zinsen",
+        "value": 4.87,
+        "taxes": 1.87,
+        "transactions": [
+            {
+                "Datum": "2025-07-01T06:46:37",
+                "Typ": "Zinsen",
+                "Wert": 4.87,
+                "Notiz": "Zinsen",
+                "Steuern": 1.87,
+            }
+        ],
+    },
+    {
+        "filename": "zinsen_no_eventType.json",
+        "event_type": PPEventType.INTEREST,
+        "title": "Zinsen",
+        "value": 4.87,
+        "taxes": 1.87,
+        "transactions": [
+            {
+                "Datum": "2025-07-01T06:46:37",
+                "Typ": "Zinsen",
+                "Wert": 4.87,
+                "Notiz": "Zinsen",
+                "Steuern": 1.87,
+            }
+        ],
+    },
+    {
+        "filename": "zusammenschluss.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Rocket Lab USA",
+        "isin": "US7731221062",
+        "isin2": "US7731211089",
+        "shares": 5.943100,
+        "shares2": 5.943100,
+        "value": 0,
+        "note": "ROCKET LAB CORP. O.N.",
+        "transactions": [
+            {
+                "Datum": "2025-05-29T13:04:58",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Rocket Lab USA",
+                "ISIN": "US7731221062",
+                "Stück": 5.9431,
+                "ISIN2": "US7731211089",
+                "Stück2": 5.9431,
+            },
+        ],
+    },
+    {
+        "filename": "zusammenschluss_no_eventType.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Rocket Lab USA",
+        "isin": "US7731221062",
+        "isin2": "US7731211089",
+        "shares": 5.943100,
+        "shares2": 5.943100,
+        "value": 0,
+        "note": "ROCKET LAB CORP. O.N.",
+        "transactions": [
+            {
+                "Datum": "2025-05-29T13:04:58",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Rocket Lab USA",
+                "ISIN": "US7731221062",
+                "Stück": 5.9431,
+                "ISIN2": "US7731211089",
+                "Stück2": 5.9431,
+            },
+        ],
+    },
+    {
+        "filename": "zusammenschluss2.json",
+        "event_type": PPEventType.SWAP,
+        "title": "Rocket Lab USA",
+        "isin": "US7731221062",
+        "isin2": "US7731211089",
+        "shares": 5.943100,
+        "shares2": 5.943100,
+        "value": 0,
+        "note": "ROCKET LAB CORP. O.N.",
+        "transactions": [
+            {
+                "Datum": "2025-05-29T13:04:58",
+                "Typ": "Swap",
+                "Wert": 0,
+                "Notiz": "Rocket Lab USA",
+                "ISIN": "US7731221062",
+                "Stück": 5.9431,
+                "ISIN2": "US7731211089",
+                "Stück2": 5.9431,
+            },
+        ],
+    },
+    {
+        "filename": "zwischenpapiere.json",
+        "event_type": PPEventType.SWAP,
+        "title": "ORSTED A/S   -ANR-",
+        "isin": "DK0064307839",
+        "isin2": "DK0064307755",
+        "shares": 119,
+        "shares2": 17,
+        "value": -151.59,
+        "note": "ORSTED A/S EM.09/25 DK 10",
+        "transactions": [
+            {
+                "Datum": "2025-10-21T07:39:39",
+                "Typ": "Swap",
+                "Wert": -151.59,
+                "ISIN": "DK0064307839",
+                "Notiz": "ORSTED A/S   -ANR-",
+                "Stück": 119.0,
+                "ISIN2": "DK0064307755",
+                "Stück2": 17.0,
+            },
+        ],
+    },
+    {
+        "filename": "zwischenpapiere2.json",
+        "event_type": PPEventType.SWAP,
+        "title": "WORLDLINE S.A. ANR",
+        "isin": "FR0014015MS9",
+        "isin2": "FR0011981968",
+        "shares": 1,
+        "shares2": 6,
+        "value": -1.21,
+        "note": "Worldline",
+        "transactions": [
+            {
+                "Datum": "2026-04-03T09:37:06",
+                "Typ": "Swap",
+                "Wert": -1.21,
+                "ISIN": "FR0014015MS9",
+                "Notiz": "WORLDLINE S.A. ANR",
+                "Stück": 1.0,
+                "ISIN2": "FR0011981968",
+                "Stück2": 6.0,
+            },
+        ],
+    },
+    {
+        "filename": "zwischenpapiere3.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Worldline",
+        "isin": "FR0011981968",
+        "shares": 1294,
+        "value": -261.39,
+        "transactions": [
+            {
+                "Datum": "2026-04-03T10:38:58",
+                "Typ": "Kauf",
+                "Wert": -261.39,
+                "ISIN": "FR0011981968",
+                "Notiz": "Worldline",
+                "Stück": 1294.0,
+            },
+        ],
+    },
+    {
+        "filename": "zwischenpapiere_no_eventType.json",
+        "event_type": PPEventType.SWAP,
+        "title": "ORSTED A/S   -ANR-",
+        "isin": "DK0064307839",
+        "isin2": "DK0064307755",
+        "shares": 119,
+        "shares2": 17,
+        "value": -151.59,
+        "note": "ORSTED A/S EM.09/25 DK 10",
+        "transactions": [
+            {
+                "Datum": "2025-10-21T07:39:39",
+                "Typ": "Swap",
+                "Wert": -151.59,
+                "ISIN": "DK0064307839",
+                "Notiz": "ORSTED A/S   -ANR-",
+                "Stück": 119.0,
+                "ISIN2": "DK0064307755",
+                "Stück2": 17.0,
+            },
+        ],
+    },
+    {
+        "filename": "zwischenvertrieb.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "Orsted",
+        "isin": "DK0064307839",
+        "isin2": "DK0060094928",
+        "shares": 119.285835,
+        "value": 0,
+        "note": "ORSTED A/S   -ANR-",
+        "transactions": [
+            {
+                "Datum": "2025-09-19T12:02:49",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S   -ANR-",
+                "ISIN": "DK0064307839",
+                "Stück": 119.285835,
+                "ISIN2": "DK0060094928",
+            }
+        ],
+    },
+    {
+        "filename": "zwischenvertrieb_no_eventType.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "Orsted",
+        "isin": "DK0064307839",
+        "isin2": "DK0060094928",
+        "shares": 119.285835,
+        "value": 0,
+        "note": "ORSTED A/S   -ANR-",
+        "transactions": [
+            {
+                "Datum": "2025-09-19T12:02:49",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "ORSTED A/S   -ANR-",
+                "ISIN": "DK0064307839",
+                "Stück": 119.285835,
+                "ISIN2": "DK0060094928",
+            }
+        ],
+    },
+    {
+        "filename": "zwischenvertrieb2.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "Worldline",
+        "isin": "FR0014015MS9",
+        "isin2": "FR0011981968",
+        "shares": 1.299376,
+        "value": 0,
+        "note": "Worldline",
+        "transactions": [
+            {
+                "Datum": "2026-03-17T10:45:33",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "Worldline",
+                "ISIN": "FR0014015MS9",
+                "Stück": 1.299376,
+                "ISIN2": "FR0011981968",
+            }
+        ],
+    },
+    {
+        "filename": "zwischenvertrieb3.json",
+        "event_type": PPEventType.SPINOFF,
+        "title": "OHB",
+        "isin": "DE000A41YFG5",
+        "isin2": "DE0005936124",
+        "shares": 1.026415,
+        "value": 0,
+        "note": "OHB",
+        "transactions": [
+            {
+                "Datum": "2026-06-29T09:09:14",
+                "Typ": "Spinoff",
+                "Wert": 0,
+                "Notiz": "OHB",
+                "ISIN": "DE000A41YFG5",
+                "Stück": 1.026415,
+                "ISIN2": "DE0005936124",
+            }
+        ],
+    },
+    {
+        "filename": "bank_transaction_incoming.json",
+        "event_type": PPEventType.DEPOSIT,
+        "title": "Max Mustermann",
+        "value": 5.15,
+        "transactions": [
+            {
+                "Datum": "2024-07-04T06:17:41",
+                "Typ": "Einlage",
+                "Wert": 5.15,
+                "Notiz": "Max Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "bank_transaction_outgoing.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "Max Mustermann",
+        "value": -50.3,
+        "transactions": [
+            {
+                "Datum": "2024-07-21T09:35:47",
+                "Typ": "Entnahme",
+                "Wert": -50.3,
+                "Notiz": "Max Mustermann",
+            }
+        ],
+    },
+    {
+        "filename": "card_transaction.json",
+        "event_type": PPEventType.REMOVAL,
+        "title": "REWE",
+        "value": -4.28,
+        "note": "card_successful_transaction",
+        "transactions": [
+            {
+                "Datum": "2024-06-03T15:10:48",
+                "Typ": "Entnahme",
+                "Wert": -4.28,
+                "Notiz": "Kartentransaktion - REWE",
+            }
+        ],
+    },
+    {
+        "filename": "interest_payout_created.json",
+        "event_type": PPEventType.INTEREST,
+        "title": "Zinsen",
+        "value": 13.56,
+        "taxes": 5.21,
+        "transactions": [
+            {
+                "Datum": "2024-07-01T04:51:32",
+                "Typ": "Zinsen",
+                "Wert": 13.56,
+                "Notiz": "Zinsen",
+                "Steuern": 5.21,
+            }
+        ],
+    },
+    {
+        "filename": "saveback_aggregate.json",
+        "event_type": ConditionalEventType.SAVEBACK,
+        "title": "S&P 500 Information Tech USD (Acc)",
+        "isin": "IE00B3WJKG14",
+        "value": -15.0,
+        "shares": 0.501924,
+        "transactions": [
+            {
+                "Datum": "2024-07-02T13:53:44",
+                "Typ": "Kauf",
+                "Wert": -15.0,
+                "Notiz": "S&P 500 Information Tech USD (Acc)",
+                "ISIN": "IE00B3WJKG14",
+                "Stück": 0.501924,
+            },
+            {
+                "Datum": "2024-07-02T13:53:44",
+                "Typ": "Einlage",
+                "Wert": 15.0,
+                "Notiz": "S&P 500 Information Tech USD (Acc)",
+            },
+        ],
+    },
+    {
+        "filename": "savings_plan_invoice_created.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Volkswagen (Vz.)",
+        "isin": "DE0007664039",
+        "value": -1.0,
+        "shares": 0.00961,
+        "transactions": [
+            {
+                "Datum": "2024-06-17T08:16:25",
+                "Typ": "Kauf",
+                "Wert": -1.0,
+                "Notiz": "Volkswagen (Vz.)",
+                "ISIN": "DE0007664039",
+                "Stück": 0.00961,
+            }
+        ],
+    },
+    {
+        "filename": "spare_change_aggregate.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "S&P 500 Information Tech USD (Acc)",
+        "isin": "IE00B3WJKG14",
+        "value": -5.81,
+        "shares": 0.208318,
+        "transactions": [
+            {
+                "Datum": "2024-06-10T13:52:18",
+                "Typ": "Kauf",
+                "Wert": -5.81,
+                "Notiz": "S&P 500 Information Tech USD (Acc)",
+                "ISIN": "IE00B3WJKG14",
+                "Stück": 0.208318,
+            }
+        ],
+    },
+    {
+        "filename": "ssp_tax_correction.json",
+        "event_type": PPEventType.TAX_REFUND,
+        "title": "Steuerkorrektur",
+        "value": 3.47,
+        "transactions": [
+            {
+                "Datum": "2024-06-11T22:45:15",
+                "Typ": "Steuerrückerstattung",
+                "Wert": 3.47,
+                "Notiz": "Steuerkorrektur",
+            }
+        ],
+    },
+    {
+        "filename": "trade_corrected.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "Worldline",
+        "isin": "FR0011981968",
+        "value": 105.85,
+        "shares": 13.0,
+        "fees": 1.0,
+        "taxes": 1.8,
+        "transactions": [
+            {
+                "Datum": "2024-12-16T09:59:01",
+                "Typ": "Verkauf",
+                "Wert": 105.85,
+                "Notiz": "Worldline",
+                "ISIN": "FR0011981968",
+                "Stück": 13.0,
+                "Gebühren": 1.0,
+                "Steuern": 1.8,
+            }
+        ],
+    },
+    {
+        "filename": "trade_invoice.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "DWS Group",
+        "isin": "DE000DWS1007",
+        "value": -221.0,
+        "shares": 5.0,
+        "fees": 1.0,
+        "transactions": [
+            {
+                "Datum": "2024-06-04T06:23:45",
+                "Typ": "Kauf",
+                "Wert": -221.0,
+                "Notiz": "DWS Group",
+                "ISIN": "DE000DWS1007",
+                "Stück": 5.0,
+                "Gebühren": 1.0,
+            }
+        ],
+    },
+    {
+        "filename": "trading_savingsplan_executed.json",
+        "event_type": ConditionalEventType.TRADE_INVOICE,
+        "title": "BASF",
+        "isin": "DE000BASF111",
+        "value": -15.0,
+        "shares": 0.316355,
+        "transactions": [
+            {
+                "Datum": "2025-02-10T09:23:13",
+                "Typ": "Kauf",
+                "Wert": -15.0,
+                "Notiz": "BASF",
+                "ISIN": "DE000BASF111",
+                "Stück": 0.316355,
+            }
+        ],
+    },
+]
 
-    # Create an instance of EventCsvFormatter
+
+@pytest.mark.parametrize("case", test_data, ids=[c["filename"] for c in test_data])
+def test_events(case):
     formatter = TransactionExporter(lang="de")
-    print()  # newline after pytest's test name on the same line
 
-    for row in test_data:
-        # Load the sample JSON file
-        with open("tests/events/" + row["filename"], "r", encoding="utf-8") as file:
-            sample_data = json.load(file)
+    with open(EVENTS_DIR / case["filename"], encoding="utf-8") as f:
+        sample_data = json.load(f)
 
-        # Parse the JSON data using the from_dict function
-        event = Event.from_dict(sample_data)
+    event = Event.from_dict(sample_data)
 
-        # Assert event type
-        assert event.event_type == row.get("event_type")
+    assert event.event_type == case.get("event_type")
 
-        # if event type is none, nothing else is to check, results will be discarded
-        if row.get("event_type") is None:
-            continue
+    if case.get("event_type") is None:
+        return
 
-        # Assert the expected values
-        assert event.title == row.get("title")
-        assert event.isin == row.get("isin")
-        assert event.isin2 == row.get("isin2")
-        assert event.shares == row.get("shares")
-        assert event.shares2 == row.get("shares2")
-        assert event.value == row.get("value")
-        assert event.fees == row.get("fees")
-        assert event.taxes == row.get("taxes")
-        assert event.note == row.get("note")
+    assert event.title == case.get("title")
+    assert event.isin == case.get("isin")
+    assert event.isin2 == case.get("isin2")
+    assert event.shares == case.get("shares")
+    assert event.shares2 == case.get("shares2")
+    assert event.value == case.get("value")
+    assert event.fees == case.get("fees")
+    assert event.taxes == case.get("taxes")
+    assert event.note == case.get("note")
 
-        # Format the event to CSV
-        transactions = list(formatter.from_event(event))
+    transactions = list(formatter.from_event(event))
 
-        # Assert that the output is not an empty string
-        rowtransactions = row.get("transactions", [])
-        for entry in rowtransactions:
-            entry.setdefault("Datum", None)
-            entry.setdefault("Typ", None)
-            entry.setdefault("Wert", None)
-            entry.setdefault("Notiz", None)
-            entry.setdefault("ISIN", None)
-            entry.setdefault("Stück", None)
-            entry.setdefault("Gebühren", None)
-            entry.setdefault("Steuern", None)
-            entry.setdefault("ISIN2", None)
-            entry.setdefault("Stück2", None)
-        assert transactions == rowtransactions
-        print(f"  ok: {row['filename']}")
+    rowtransactions = case.get("transactions", [])
+    for entry in rowtransactions:
+        entry.setdefault("Datum", None)
+        entry.setdefault("Typ", None)
+        entry.setdefault("Wert", None)
+        entry.setdefault("Notiz", None)
+        entry.setdefault("ISIN", None)
+        entry.setdefault("Stück", None)
+        entry.setdefault("Gebühren", None)
+        entry.setdefault("Steuern", None)
+        entry.setdefault("ISIN2", None)
+        entry.setdefault("Stück2", None)
+    assert transactions == rowtransactions


### PR DESCRIPTION
Cleanups and fixes to dl_docs processing, try to cover lot of new and changed events/documents from TR.
Flatten document subfolders for Trades, Sparplan, Saveback, RoundUp (Abrechnung), Zinsen, Einzahlungen, Auszahlungen, and Aktien-Bonus (now under Misc).
Remove the history file mechanism.
Add testing of download paths and add more test fixtures.
Parametrize test_events for per-fixture pytest output.
