### PR TITLE
Support new login method

### DIFF
--- a/pytr/account.py
+++ b/pytr/account.py
@@ -19,7 +19,7 @@ def get_settings(tr):
         return formatted_json
 
 
-def login(phone_no=None, pin=None, store_credentials=False, waf_token="playwright"):
+def login(phone_no=None, pin=None, store_credentials=False, waf_token="playwright", v2=False):
     """
     Handle credentials parameters and store to credentials file if requested.
     If no parameters are set but are needed then ask for input
@@ -54,7 +54,7 @@ def login(phone_no=None, pin=None, store_credentials=False, waf_token="playwrigh
         else:
             save_cookies = False
 
-    tr = TradeRepublicApi(phone_no=phone_no, pin=pin, save_cookies=save_cookies, waf_token=waf_token)
+    tr = TradeRepublicApi(phone_no=phone_no, pin=pin, save_cookies=save_cookies, waf_token=waf_token, use_v2_login=v2)
 
     # Use same login as app.traderepublic.com
     if not tr.resume_websession():
@@ -64,20 +64,27 @@ def login(phone_no=None, pin=None, store_credentials=False, waf_token="playwrigh
             log.fatal(str(e))
             sys.exit(1)
         request_time = time.time()
-        print("Enter the code you received to your mobile app as a notification.")
-        print(f"Enter nothing if you want to receive the (same) code as SMS. (Countdown: {countdown})")
-        code = input("Code: ")
-        if code == "":
-            countdown = countdown - (time.time() - request_time)
-            for remaining in range(int(countdown)):
-                print(
-                    f"Need to wait {int(countdown - remaining)} seconds before requesting SMS...",
-                    end="\r",
-                )
-                time.sleep(1)
-            print()
-            tr.resend_weblogin()
-            code = input("SMS requested. Enter the confirmation code:")
+        if v2:
+            if tr.weblogin_needs_authenticator:
+                code = input("Enter the code from your authenticator app: ")
+            else:
+                print(f"Confirm the login in your Trade Republic app. (Countdown: {countdown})")
+                code = None
+        else:
+            print("Enter the code you received to your mobile app as a notification.")
+            print(f"Enter nothing if you want to receive the (same) code as SMS. (Countdown: {countdown})")
+            code = input("Code: ")
+            if code == "":
+                countdown = countdown - (time.time() - request_time)
+                for remaining in range(int(countdown)):
+                    print(
+                        f"Need to wait {int(countdown - remaining)} seconds before requesting SMS...",
+                        end="\r",
+                    )
+                    time.sleep(1)
+                print()
+                tr.resend_weblogin()
+                code = input("SMS requested. Enter the confirmation code:")
         tr.complete_weblogin(code)
         log.info("Logged in.")
 

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -21,14 +21,19 @@
 # SOFTWARE.
 
 import asyncio
+import base64
+import hashlib
 import json
+import os
 import pathlib
+import platform
 import re
 import ssl
 import subprocess
 import time
 import urllib.parse
 import uuid
+from datetime import datetime
 from http.cookiejar import Cookie, MozillaCookieJar
 from typing import Any, Dict
 
@@ -46,6 +51,23 @@ BASE_DIR = home / ".pytr"
 CREDENTIALS_FILE = BASE_DIR / "credentials"
 COOKIES_FILE = BASE_DIR / "cookies.txt"
 
+# errorCodes the v2 login process can answer with, mapped to readable messages.
+LOGIN_ERRORS = {
+    "PROCESS_GONE": "The login request expired. Please start again.",
+    "ALREADY_PROCESSED": "The login request was rejected or has already been used.",
+    "NOT_FOUND": "Trade Republic does not know this login request.",
+    "TOO_MANY_REQUESTS": "Too many attempts. Please wait before trying again.",
+    "VALIDATION_CODE_INVALID": "That authenticator code is not correct.",
+    "VALIDATION_CODE_ALREADY_USED": "That authenticator code was already used.",
+}
+
+# Build version of the web frontend. Sent on every api/v2 login call.
+# Moves with each frontend deployment; bump when TR starts rejecting stale versions.
+APP_VERSION = "2.2631.13"
+
+# The web frontend's API client identifies itself with this platform on all v2 login calls.
+WEB_PLATFORM = "web-pro"
+
 
 class TradeRepublicApi:
     _default_headers = {
@@ -55,6 +77,8 @@ class TradeRepublicApi:
     _waf_login_url = "https://app.traderepublic.com/login"
 
     _process_id = None
+    _required_action = None
+    _device_info = None
     _session_expires_at = 0
 
     _ws = None
@@ -75,11 +99,13 @@ class TradeRepublicApi:
         credentials_file=None,
         cookies_file=None,
         waf_token="playwright",
+        use_v2_login=False,
     ):
         self.log = get_logger(__name__)
         self._locale = locale
         self._save_cookies = save_cookies
         self._waf_token = waf_token
+        self._use_v2_login = use_v2_login
 
         self._credentials_file = pathlib.Path(credentials_file) if credentials_file else CREDENTIALS_FILE
 
@@ -205,6 +231,60 @@ class TradeRepublicApi:
         )
         self._websession.cookies.set_cookie(cookie)
 
+    def _stable_device_id(self):
+        """An id that stays the same for this installation.
+
+        The web frontend derives it from a canvas fingerprint hashed with SHA-512.
+        There is no canvas here, so the hash covers what identifies this machine
+        instead. Same length, same alphabet, no state on disk and no request to anyone.
+        """
+        seed = "|".join([str(uuid.getnode()), platform.node(), platform.machine(), platform.system()])
+        return hashlib.sha512(seed.encode()).hexdigest()
+
+    def _timezone_name(self):
+        """The IANA name of the local timezone, with the frontend's own fallback."""
+        try:
+            return str(pathlib.Path("/etc/localtime").resolve()).split("zoneinfo/")[1]
+        except (OSError, IndexError):
+            return "Etc/UTC"
+
+    def _login_headers(self):
+        """The headers Trade Republic requires on the api/v2 login calls.
+
+        Without them the endpoints answer 400 MISSING_REQUIRED_HEADER. The web
+        frontend sends the same set on all three of them: a base64-encoded JSON
+        description of the device, its build version, the platform its API client is
+        configured with, and the language it wants to be answered in.
+
+        Fields the frontend can only fill from a browser are left out rather than
+        invented. It omits them itself when the browser doesn't provide them
+        (`model` on desktop, `deviceMemory` outside Chromium), so their absence
+        is accepted by the server. `screen` is the one value with no counterpart here.
+        """
+        if self._device_info is None:
+            chrome = re.search(r"Chrome/([\d.]+)", self._websession.headers.get("User-Agent", ""))
+            offset = datetime.now().astimezone().utcoffset()
+            device = {
+                "stableDeviceId": self._stable_device_id(),
+                "browser": "Chrome",
+                "browserVersion": chrome.group(1) if chrome else "",
+                "os": platform.system(),
+                "osVersion": platform.release(),
+                "timezone": self._timezone_name(),
+                # JavaScript counts the offset the other way round than Python does.
+                "timezoneOffset": -int(offset.total_seconds() // 60) if offset else 0,
+                "screen": "1920x1080x24",
+                "preferredLanguages": [self._locale],
+                "numberOfCores": os.cpu_count() or 1,
+            }
+            self._device_info = base64.b64encode(json.dumps(device).encode()).decode()
+        return {
+            "X-TR-Device-Info": self._device_info,
+            "X-TR-App-Version": APP_VERSION,
+            "X-Tr-Platform": WEB_PLATFORM,
+            "Accept-Language": self._locale,
+        }
+
     def initiate_weblogin(self):
         self.log.info("Initiating web login...")
 
@@ -221,9 +301,12 @@ class TradeRepublicApi:
         else:
             self.log.warning("No WAF token available.")
 
+        extra_headers = self._login_headers() if self._use_v2_login else None
+        login_path = "/api/v2/auth/web/login" if self._use_v2_login else "/api/v1/auth/web/login"
         r = self._websession.post(
-            f"{self._host}/api/v1/auth/web/login",
+            f"{self._host}{login_path}",
             json={"phoneNumber": self.phone_no, "pin": self.pin},
+            headers=extra_headers,
         )
         self.log.debug(f"Web login returned: {r.status_code}")
         r.raise_for_status()
@@ -237,22 +320,109 @@ class TradeRepublicApi:
                 raise ValueError(str(err))
             else:
                 raise ValueError("processId not in reponse")
-        return int(j["countdownInSeconds"]) + 1
+        if not self._use_v2_login:
+            return int(j["countdownInSeconds"]) + 1
+        if self._process_id is None:
+            raise ValueError("Trade Republic completed the login without a confirmation step.")
+        # The second factor is on the login process, not in the login response.
+        self._required_action = self._get_weblogin_process(quiet=True).get("requiredAction")
+        # v2 does not always send countdownInSeconds; the web frontend falls back to 120s.
+        return int(j.get("countdownInSeconds", 120)) + 1
+
+    @property
+    def weblogin_needs_authenticator(self):
+        """Whether complete_weblogin() needs a code from the user's authenticator app."""
+        return self._required_action == "AUTHENTICATOR_VERIFICATION"
 
     def resend_weblogin(self):
+        if self._use_v2_login:
+            self.log.warning(
+                "Trade Republic removed the SMS resend endpoint along with the v1 web login. "
+                "Confirm the login in the Trade Republic mobile app instead."
+            )
+            return
         r = self._websession.post(
             f"{self._host}/api/v1/auth/web/login/{self._process_id}/resend",
             headers=self._default_headers,
         )
         r.raise_for_status()
 
-    def complete_weblogin(self, verify_code):
+    def complete_weblogin(self, verify_code=None):
         if not self._process_id and not self._websession:
             raise ValueError("Initiate web login first.")
 
-        r = self._websession.post(f"{self._host}/api/v1/auth/web/login/{self._process_id}/{verify_code}")
-        r.raise_for_status()
+        if not self._use_v2_login:
+            r = self._websession.post(f"{self._host}/api/v1/auth/web/login/{self._process_id}/{verify_code}")
+            r.raise_for_status()
+            self.save_websession()
+            return
+
+        if self.weblogin_needs_authenticator:
+            if not verify_code:
+                raise ValueError("This account needs a code from your authenticator app.")
+            r = self._websession.post(
+                f"{self._host}/api/v2/auth/web/login/processes/{self._process_id}/authenticator-verification",
+                json={"code": verify_code},
+                headers=self._login_headers(),
+            )
+            self._raise_for_login_error(r)
+        else:
+            self._await_weblogin_confirmation()
         self.save_websession()
+
+    def _raise_for_login_error(self, r):
+        """Raise a readable error, keeping the process id out of the message."""
+        if r.status_code < 400:
+            return
+        try:
+            code = r.json()["errors"][0]["errorCode"]
+        except (ValueError, KeyError, IndexError, TypeError):
+            raise ValueError(f"Login failed with status {r.status_code}.") from None
+        raise ValueError(LOGIN_ERRORS.get(code, f"Login failed: {code}."))
+
+    def _get_weblogin_process(self, quiet=False):
+        """Read the state of the current login process."""
+        r = self._websession.get(
+            f"{self._host}/api/v2/auth/web/login/processes/{self._process_id}",
+            headers=self._login_headers(),
+        )
+        if quiet and r.status_code >= 400:
+            return {}
+        self._raise_for_login_error(r)
+        return r.json()
+
+    def _weblogin_deadline(self, process, fallback=120):
+        """Return deadline as a Unix timestamp; fall back to a fixed window."""
+        expires_at = process.get("expiresAt")
+        try:
+            if isinstance(expires_at, (int, float)):
+                return expires_at / 1000 if expires_at > 1e11 else float(expires_at)
+            return datetime.fromisoformat(str(expires_at).replace("Z", "+00:00")).timestamp()
+        except (TypeError, ValueError):
+            return time.time() + fallback
+
+    def _await_weblogin_confirmation(self, interval=2):
+        """Poll the login process until confirmed in the Trade Republic mobile app."""
+        process = self._get_weblogin_process()
+        deadline = self._weblogin_deadline(process)
+        self.log.info("Waiting for you to confirm the login in the Trade Republic app...")
+        announced = 0.0
+        while True:
+            status = process.get("status")
+            self.log.debug(f"Login process status: {status}")
+            if status in ("CONFIRMED", "COMPLETED"):
+                self.log.info("Login confirmed.")
+                return
+            if status != "PENDING":
+                raise ValueError(f"Unexpected login process status: {status!r}")
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                raise TimeoutError("The login was not confirmed in time.")
+            if time.time() - announced >= 10:
+                self.log.info(f"Still waiting, {int(remaining)}s left...")
+                announced = time.time()
+            time.sleep(interval)
+            process = self._get_weblogin_process()
 
     def save_websession(self):
         if self._save_cookies:

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -91,6 +91,15 @@ def get_main_parser():
         action="store_true",
         default=False,
     )
+    parser_login_args.add_argument(
+        "--v2",
+        help=(
+            "Use the v2 web-login flow: confirm in the Trade Republic mobile app "
+            "instead of entering an SMS/notification code. Also supports authenticator-app accounts."
+        ),
+        action="store_true",
+        default=False,
+    )
 
     # parent subparser for lang option
     parser_lang = argparse.ArgumentParser(add_help=False)
@@ -535,6 +544,7 @@ def main():
             pin=args.pin,
             store_credentials=args.store_credentials,
             waf_token=args.waf_token,
+            v2=args.v2,
         )
     elif args.command == "portfolio":
         Portfolio(
@@ -543,6 +553,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             args.include_watchlist,
             instruments_to_ignore=re.split(r"[,;]", args.ignore) if args.ignore else [],
@@ -563,6 +574,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             isins,
             output=args.output,
@@ -578,6 +590,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             args.isin,
         ).get()
@@ -590,6 +603,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             args.output,
             args.format,
@@ -623,6 +637,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             args.outputdir,
             not_before,
@@ -688,6 +703,7 @@ def main():
                 pin=args.pin,
                 store_credentials=args.store_credentials,
                 waf_token=args.waf_token,
+                v2=args.v2,
             ),
             args.outputfile,
             decimal_localization=args.decimal_localization,

--- a/tests/test_api_urls.py
+++ b/tests/test_api_urls.py
@@ -1,0 +1,277 @@
+"""Pin the web login endpoints, their required headers and the login process state machine."""
+
+import base64
+import json as jsonlib
+import re
+from typing import Any
+
+import pytest
+import requests
+
+from pytr.api import TradeRepublicApi
+
+LOGIN = "https://api.traderepublic.com/api/v2/auth/web/login"
+PROCESS = "https://api.traderepublic.com/api/v2/auth/web/login/processes/pid-1"
+
+
+def _error(code: str) -> dict[str, Any]:
+    return {"errors": [{"errorCode": code, "errorMessage": None, "meta": None}]}
+
+
+class _Response:
+    def __init__(self, url: str, payload: Any = None, status_code: int = 200):
+        self.url = url
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            # Mirrors requests: the message carries the URL, and with it the process id.
+            raise requests.HTTPError(f"{self.status_code} Client Error for url: {self.url}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _Session:
+    """Records requests instead of sending them. Replies come from a queue."""
+
+    def __init__(self, replies: list[Any]):
+        self.calls: list[dict[str, Any]] = []
+        self._replies = list(replies)
+        self.cookies = None
+        self.headers = dict(TradeRepublicApi._default_headers)
+
+    def _record(self, method: str, url: str, json: Any = None, headers: Any = None) -> _Response:
+        self.calls.append({"method": method, "url": url, "json": json, "headers": headers or {}})
+        reply = self._replies.pop(0) if self._replies else {}
+        status, payload = reply if isinstance(reply, tuple) else (200, reply)
+        return _Response(url, payload, status)
+
+    def post(self, url, json=None, headers=None):
+        return self._record("POST", url, json, headers)
+
+    def get(self, url, headers=None):
+        return self._record("GET", url, None, headers)
+
+    def request(self, method, url, data=None):
+        return self._record(method, url, None, None)
+
+
+def _api(replies):
+    tr = TradeRepublicApi(phone_no="+490000000000", pin="0000", waf_token=None, use_v2_login=True)
+    tr._websession = _Session(replies)
+    return tr
+
+
+def _urls(tr):
+    return [c["url"] for c in tr._websession.calls]
+
+
+# --- initiate_weblogin ---------------------------------------------------------------
+
+
+def test_initiate_weblogin_uses_v2():
+    tr = _api([{"processId": "pid-1", "countdownInSeconds": 60}, {"status": "PENDING"}])
+
+    countdown = tr.initiate_weblogin()
+
+    assert tr._websession.calls[0]["url"] == LOGIN
+    assert tr._websession.calls[0]["json"] == {"phoneNumber": "+490000000000", "pin": "0000"}
+    assert tr._process_id == "pid-1"
+    assert countdown == 61
+
+
+def test_initiate_weblogin_without_countdown_defaults_to_120():
+    tr = _api([{"processId": "pid-1"}, {"status": "PENDING"}])
+
+    assert tr.initiate_weblogin() == 121
+
+
+def test_initiate_weblogin_reads_required_action_from_the_process():
+    """The second factor sits on the login process, not in the login response."""
+    tr = _api([{"processId": "pid-1"}, {"requiredAction": "AUTHENTICATOR_VERIFICATION"}])
+
+    tr.initiate_weblogin()
+
+    assert _urls(tr)[1] == PROCESS
+    assert tr.weblogin_needs_authenticator is True
+
+
+def test_initiate_weblogin_falls_back_to_in_app_when_process_unreadable():
+    tr = _api([{"processId": "pid-1"}, (500, _error("UNKNOWN_ERROR"))])
+
+    tr.initiate_weblogin()
+
+    assert tr.weblogin_needs_authenticator is False
+
+
+def test_initiate_weblogin_rejects_a_null_process_id():
+    tr = _api([{"processId": None}])
+
+    with pytest.raises(ValueError, match="without a confirmation step"):
+        tr.initiate_weblogin()
+
+
+# --- complete_weblogin ---------------------------------------------------------------
+
+
+def test_complete_weblogin_posts_code_to_authenticator_verification():
+    tr = _api([{}])
+    tr._process_id = "pid-1"
+    tr._required_action = "AUTHENTICATOR_VERIFICATION"
+
+    tr.complete_weblogin("123456")
+
+    call = tr._websession.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"] == f"{PROCESS}/authenticator-verification"
+    assert call["json"] == {"code": "123456"}
+
+
+def test_complete_weblogin_requires_a_code_when_authenticator_is_needed():
+    tr = _api([])
+    tr._process_id = "pid-1"
+    tr._required_action = "AUTHENTICATOR_VERIFICATION"
+
+    with pytest.raises(ValueError, match="authenticator app"):
+        tr.complete_weblogin(None)
+
+
+def test_complete_weblogin_polls_the_process_for_in_app_confirmation():
+    tr = _api([{"status": "PENDING"}, {"status": "CONFIRMED"}])
+    tr._process_id = "pid-1"
+
+    tr.complete_weblogin(None)
+
+    assert [c["method"] for c in tr._websession.calls] == ["GET", "GET"]
+    assert set(_urls(tr)) == {PROCESS}
+
+
+# --- login process state machine -----------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["CONFIRMED", "COMPLETED"])
+def test_poll_accepts_both_terminal_states(status):
+    tr = _api([{"status": status}])
+    tr._process_id = "pid-1"
+
+    tr._await_weblogin_confirmation(interval=0)
+
+
+def test_poll_reports_a_rejected_login():
+    tr = _api([(410, _error("ALREADY_PROCESSED"))])
+    tr._process_id = "pid-1"
+
+    with pytest.raises(ValueError, match="rejected"):
+        tr._await_weblogin_confirmation(interval=0)
+
+
+def test_poll_reports_an_expired_login():
+    tr = _api([(410, _error("PROCESS_GONE"))])
+    tr._process_id = "pid-1"
+
+    with pytest.raises(ValueError, match="expired"):
+        tr._await_weblogin_confirmation(interval=0)
+
+
+def test_poll_times_out_at_the_server_side_expiry():
+    tr = _api([{"status": "PENDING", "expiresAt": "2020-01-01T00:00:00Z"}])
+    tr._process_id = "pid-1"
+
+    with pytest.raises(TimeoutError):
+        tr._await_weblogin_confirmation(interval=0)
+
+
+def test_deadline_prefers_expires_at_over_the_fallback():
+    tr = _api([])
+
+    assert tr._weblogin_deadline({"expiresAt": "2999-01-01T00:00:00Z"}) > tr._weblogin_deadline({}) + 60
+
+
+def test_login_errors_do_not_leak_the_process_id():
+    """raise_for_status() would put the URL, and with it the process id, into the message."""
+    tr = _api([(410, _error("PROCESS_GONE"))])
+    tr._process_id = "pid-1"
+
+    with pytest.raises(ValueError) as excinfo:
+        tr._await_weblogin_confirmation(interval=0)
+
+    assert "pid-1" not in str(excinfo.value)
+    assert "http" not in str(excinfo.value)
+
+
+def test_resend_weblogin_warns_instead_of_calling_a_removed_endpoint():
+    tr = _api([])
+
+    tr.resend_weblogin()
+
+    assert tr._websession.calls == []
+
+
+# --- required headers ----------------------------------------------------------------
+
+REQUIRED_HEADERS = ("X-TR-Device-Info", "X-TR-App-Version", "X-Tr-Platform")
+
+
+def _every_login_call():
+    """Every v2 login call pytr makes: start, poll, authenticator verification."""
+    poll = _api([{"processId": "pid-1"}, {"status": "PENDING"}, {"status": "CONFIRMED"}])
+    poll.initiate_weblogin()
+    poll.complete_weblogin(None)
+
+    verify = _api([{}])
+    verify._process_id = "pid-1"
+    verify._required_action = "AUTHENTICATOR_VERIFICATION"
+    verify.complete_weblogin("123456")
+
+    return poll._websession.calls + verify._websession.calls
+
+
+def test_every_v2_login_call_sends_the_required_headers():
+    """Without them Trade Republic answers 400 MISSING_REQUIRED_HEADER."""
+    calls = _every_login_call()
+
+    assert [c["url"] for c in calls] == [LOGIN, PROCESS, PROCESS, f"{PROCESS}/authenticator-verification"]
+    for call in calls:
+        for header in REQUIRED_HEADERS:
+            assert call["headers"].get(header), f"{header} missing on {call['method']} {call['url']}"
+
+
+def test_device_info_is_base64_encoded_json():
+    device = jsonlib.loads(base64.b64decode(_api([])._login_headers()["X-TR-Device-Info"]))
+
+    # The frontend hashes a canvas fingerprint with SHA-512; same length, same alphabet.
+    assert re.fullmatch(r"[0-9a-f]{128}", device["stableDeviceId"])
+    assert device["browser"] == "Chrome"
+    # Taken from the User-Agent, so the two cannot drift apart.
+    assert device["browserVersion"] in TradeRepublicApi._default_headers["User-Agent"]
+
+
+def test_device_info_is_the_same_for_every_login():
+    """The frontend builds it once per page load; ours must not wander between runs."""
+    assert _api([])._login_headers()["X-TR-Device-Info"] == _api([])._login_headers()["X-TR-Device-Info"]
+
+
+def test_app_version_and_platform_come_from_the_web_frontend():
+    headers = _api([])._login_headers()
+
+    # A build version of the frontend, not a pytr version.
+    assert re.fullmatch(r"\d+\.\d+\.\d+", headers["X-TR-App-Version"])
+    assert headers["X-Tr-Platform"] == "web-pro"
+
+
+# --- endpoints that must NOT move ----------------------------------------------------
+
+
+def test_settings_stays_on_v2_account_and_v1_session():
+    """Neither endpoint was part of the v1 login removal."""
+    tr = _api([{}, {}])
+    tr._session_expires_at = 0
+
+    tr.settings()
+
+    assert _urls(tr) == [
+        "https://api.traderepublic.com/api/v1/auth/web/session",
+        "https://api.traderepublic.com/api/v2/auth/account",
+    ]


### PR DESCRIPTION
Trade Republic added new login endpoints and it seems that there are accounts which require it. This PR brings support for the new endpoints.

To activate it, one must use the option --v2. The old v1 login endpoint still stays the default.

This is basically the work of @tharshan09 in PR #373, enriched with the command line parameter to switch login methods.
