### PR TITLE
Make playwright optional and bound the awswaf path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,19 @@ dependencies = [
     "curl_cffi",
     "packaging",
     "pathvalidate",
-    "playwright",
     "pygments",
     "requests_futures",
     "shtab",
     "websockets>=14",
 ]
+
+[project.optional-dependencies]
+# Only `--waf-token playwright` (the CLI default) needs this, and it drags in a
+# ~130 MB package plus a ~630 MB Chromium download that `playwright install`
+# fetches separately. The pure-Python `--waf-token awswaf` path solves the same
+# challenge without either, so deployments that use it — or that find their IP
+# is not challenged at all — should not have to carry the browser.
+playwright = ["playwright"]
 
 [project.scripts]
 pytr = "pytr.main:main"

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -29,7 +29,6 @@ import pathlib
 import platform
 import re
 import ssl
-import subprocess
 import time
 import urllib.parse
 import uuid
@@ -41,15 +40,34 @@ import certifi
 import requests
 import websockets
 from curl_cffi import requests as cffi_requests
-from playwright.sync_api import sync_playwright
 
-from pytr.awswaf.aws import AwsWaf
 from pytr.utils import get_logger
+
+# `playwright` and `pytr.awswaf` are imported lazily inside the two
+# `_fetch_waf_token_*` methods, not here. Both are only reachable when the
+# caller asks for that specific WAF strategy, and importing them at module
+# level made every consumer pay for them unconditionally:
+#   - `playwright` is an optional extra (see pyproject). A module-level import
+#     makes `import pytr.api` fail outright when it is not installed, which
+#     would defeat the point of making it optional.
+#   - `pytr.awswaf` reaches the network and reads `webgl.json` from disk at
+#     import time (`awswaf/fingerprint.py`). Deferring the import means a
+#     deployment that never selects `waf_token="awswaf"` neither performs that
+#     file IO nor carries the code in a hot import path.
 
 home = pathlib.Path.home()
 BASE_DIR = home / ".pytr"
 CREDENTIALS_FILE = BASE_DIR / "credentials"
 COOKIES_FILE = BASE_DIR / "cookies.txt"
+
+# Hosts that `_fetch_waf_token_awswaf` is allowed to talk to. The challenge
+# endpoint is scraped out of the login page with a regular expression, so
+# whatever `app.traderepublic.com` serves decides where the follow-up requests
+# for `/inputs` and `/verify` go — that is a server-side request forgery
+# primitive if left unchecked. AWS serves WAF challenge tokens exclusively from
+# `*.token.awswaf.com`, so pinning the suffix costs nothing and removes the
+# primitive. Comparison is on the parsed host, never on the raw URL string.
+_AWSWAF_ALLOWED_HOST_SUFFIX = ".token.awswaf.com"
 
 # errorCodes the v2 login process can answer with, mapped to readable messages.
 LOGIN_ERRORS = {
@@ -134,6 +152,8 @@ class TradeRepublicApi:
         Get the AWS WAF token, using the awswaf library.
         """
 
+        from pytr.awswaf.aws import AwsWaf
+
         self.log.info("Retrieving AWS WAF token using awswaf...")
         try:
             session = cffi_requests.Session(impersonate="chrome")
@@ -143,6 +163,16 @@ class TradeRepublicApi:
                 self.log.warning("AWS WAF token not acquired. challenge.js URL not found in login page.")
                 return None
             challenge_js_url = m.group(1)
+            # The URL above came out of a regular expression over whatever the
+            # login page returned, and everything below turns it into outbound
+            # requests. Check the host before the first of them, not after.
+            host = urllib.parse.urlparse(challenge_js_url).hostname or ""
+            if not host.lower().endswith(_AWSWAF_ALLOWED_HOST_SUFFIX):
+                self.log.warning(
+                    "AWS WAF token not acquired. challenge.js host is not an AWS WAF endpoint (expected *%s).",
+                    _AWSWAF_ALLOWED_HOST_SUFFIX,
+                )
+                return None
             waf_endpoint = challenge_js_url.split("https://", 1)[1].rsplit("/challenge.js", 1)[0]
             challenge_js = session.get(challenge_js_url).text
             token = AwsWaf(waf_endpoint, "app.traderepublic.com", challenge_js)()
@@ -158,52 +188,58 @@ class TradeRepublicApi:
         """
         Get the AWS WAF token, using a Playwright browser session.
 
-        One-time setup needed:
-            playwright install chromium
+        Requires the optional `playwright` extra plus its browser binary:
+            pip install 'pytr[playwright]' && playwright install chromium
+
+        Neither is installed automatically. An earlier version of this method
+        caught *every* exception — a network blip, a WAF change, a timeout —
+        and answered it by shelling out to `playwright install chromium`, i.e.
+        by downloading and executing a browser at runtime, in the process that
+        is holding the user's PIN and Trade Republic cookies. That download
+        bypasses whatever pinning the installing environment applied to its
+        dependencies, and it only ever helped for one of the many failures it
+        was triggered by. A missing browser is now reported like any other
+        failure and left to the operator to fix deliberately.
         """
+        try:
+            from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
+        except ImportError:
+            self.log.error(
+                "Failed to get AWS WAF token: playwright is not installed. "
+                "Install the optional extra with `pip install 'pytr[playwright]'` "
+                "and then run `playwright install chromium`."
+            )
+            raise
 
         self.log.info("Retrieving AWS WAF token using Playwright...")
 
-        called_playwright_install = False
-        while True:
-            try:
-                with sync_playwright() as p:
-                    browser = p.chromium.launch(
-                        headless=True,
-                        args=["--no-sandbox", "--disable-setuid-sandbox"],
-                    )
-                    context = browser.new_context()
-                    page = context.new_page()
-                    page.goto(
-                        "https://app.traderepublic.com/login",
-                        wait_until="domcontentloaded",
-                        timeout=timeout_ms,
-                    )
-                    deadline = time.time() + timeout_ms / 1000
-                    token = None
-                    while time.time() < deadline:
-                        for c in context.cookies():
-                            if c["name"] == "aws-waf-token":
-                                token = c["value"]
-                                break
-                        if token:
+        try:
+            with sync_playwright() as p:
+                browser = p.chromium.launch(
+                    headless=True,
+                    args=["--no-sandbox", "--disable-setuid-sandbox"],
+                )
+                context = browser.new_context()
+                page = context.new_page()
+                page.goto(
+                    "https://app.traderepublic.com/login",
+                    wait_until="domcontentloaded",
+                    timeout=timeout_ms,
+                )
+                deadline = time.time() + timeout_ms / 1000
+                token = None
+                while time.time() < deadline:
+                    for c in context.cookies():
+                        if c["name"] == "aws-waf-token":
+                            token = c["value"]
                             break
-                        time.sleep(0.5)
-                    browser.close()
-                done = True
-            except Exception as e:
-                if called_playwright_install:
-                    self.log.error("Failed to get AWS WAF token.")
-                    raise
-                else:
-                    self.log.warning("%s", e)
-                    self.log.info('Running "playwright install chromium"...')
-                    called_playwright_install = True
-                    done = False
-                    subprocess.run(["playwright", "install", "chromium"], check=True)
-                    self.log.info("Calling Playwright once more...")
-            if done:
-                break
+                    if token:
+                        break
+                    time.sleep(0.5)
+                browser.close()
+        except Exception:
+            self.log.error("Failed to get AWS WAF token.")
+            raise
 
         if not token:
             self.log.warning("AWS WAF token not acquired. Value is None.")

--- a/pytr/awswaf/aws.py
+++ b/pytr/awswaf/aws.py
@@ -147,6 +147,12 @@ class AwsWaf:
         checksum, fp = get_fp(self.user_agent)
         bandwidth_sizes = self._js_config.get("bandwidth_sizes", {})
         solution = solver(inputs["challenge"]["input"], checksum, inputs["difficulty"], bandwidth_sizes=bandwidth_sizes)
+        if solution is None:
+            # The proof-of-work solvers give up instead of spinning forever on a
+            # difficulty the server picked (see verify.py). Stop here rather than
+            # posting a null solution to /verify, where the failure would surface
+            # as a KeyError on the response instead of as what it is.
+            raise ValueError(f"Could not solve WAF challenge of type {challenge_type} within the allotted budget")
         return {
             "challenge": inputs["challenge"],
             "checksum": checksum,

--- a/pytr/awswaf/verify.py
+++ b/pytr/awswaf/verify.py
@@ -28,7 +28,29 @@
 import binascii
 import hashlib
 import itertools
+import time
 from typing import Any, Callable, Optional
+
+# Bounds for the two proof-of-work solvers below.
+#
+# Both used to loop over `itertools.count()` with no exit other than success,
+# while `difficulty` arrives from the WAF's own `/inputs` response — so the
+# server on the other end decided how long this process would spin. Two ways
+# that ends badly: a difficulty above 256 can never be satisfied at all
+# (`_check` compares a 32-byte digest against a longer all-zero prefix, which
+# is false for every possible digest), and values below that are already
+# computationally out of reach while still looking like a legitimate
+# challenge. Either way a login someone is waiting on hangs forever.
+#
+# Giving up returns `None`, which `build_payload` turns into a clean error.
+# A WAF token that takes longer than the deadline is worthless anyway: the
+# caller is a synchronous login request.
+_MAX_SOLVABLE_DIFFICULTY = 256
+_POW_DEADLINE_SECONDS = 30.0
+# The deadline is only consulted every N nonces — a `time.monotonic()` call per
+# sha256 would cost more than the hash it is guarding. scrypt is expensive
+# enough per iteration to check every time.
+_POW_TIME_CHECK_INTERVAL = 4096
 
 
 def _check(digest: bytes, difficulty: int) -> bool:
@@ -41,11 +63,16 @@ def _check(digest: bytes, difficulty: int) -> bool:
 
 
 def hash_pow(challenge: str, salt: str, difficulty: int, **kwargs) -> Optional[str]:
+    if difficulty > _MAX_SOLVABLE_DIFFICULTY:
+        return None
     prefix = (challenge + salt).encode()
+    deadline = time.monotonic() + _POW_DEADLINE_SECONDS
     for nonce in itertools.count():
         digest = hashlib.sha256(prefix + str(nonce).encode()).digest()
         if _check(digest, difficulty):
             return str(nonce)
+        if nonce % _POW_TIME_CHECK_INTERVAL == 0 and time.monotonic() > deadline:
+            return None
     return None
 
 
@@ -64,7 +91,10 @@ def compute_scrypt_nonce(
     dklen: int = 16,
     **kwargs,
 ) -> Optional[str]:
+    if difficulty > _MAX_SOLVABLE_DIFFICULTY:
+        return None
     prefix = challenge + salt
+    deadline = time.monotonic() + _POW_DEADLINE_SECONDS
     for nonce in itertools.count():
         digest = hashlib.scrypt(
             password=f"{prefix}{nonce}".encode(),
@@ -76,10 +106,19 @@ def compute_scrypt_nonce(
         )
         if _check(digest, difficulty):
             return str(nonce)
+        if time.monotonic() > deadline:
+            return None
     return None
 
 
 _DEFAULT_BANDWIDTH_SIZES = {1: 0x400, 2: 0xA * 0x400, 3: 0x64 * 0x400, 4: 0x100000, 5: 0xA * 0x100000}
+
+# The largest entry in the table above. `bandwidth_sizes` can also arrive from
+# `parse_challenge_js`, i.e. from numbers scraped out of a page with a regular
+# expression, and the buffer is allocated in one go. Without a ceiling a single
+# rewritten constant turns into an out-of-memory kill of the whole process —
+# which, in this application, is the process holding the user's session.
+_MAX_BANDWIDTH_BYTES = 0xA * 0x100000
 
 
 def network_bandwidth(challenge: str, salt: str, difficulty: int, **kwargs) -> str:
@@ -88,6 +127,11 @@ def network_bandwidth(challenge: str, salt: str, difficulty: int, **kwargs) -> s
 
     sizes = kwargs.get("bandwidth_sizes") or _DEFAULT_BANDWIDTH_SIZES
     size = sizes.get(difficulty, 0x400)
+    try:
+        size = int(size)
+    except (TypeError, ValueError):
+        size = 0x400
+    size = min(max(size, 0), _MAX_BANDWIDTH_BYTES)
     return base64.b64encode(b"\x00" * size).decode()
 
 

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -82,7 +82,12 @@ def get_main_parser():
     parser_login_args.add_argument("-p", "--pin", help="TradeRepublic pin")
     parser_login_args.add_argument(
         "--waf-token",
-        help='AWS WAF token value or the method to obtain it. Values: "playwright", "awswaf" or a token string, e.g. an aws-waf-token cookie captured from a browser session.',
+        help=(
+            'AWS WAF token value or the method to obtain it. Values: "playwright" (needs the '
+            "optional extra: pip install 'pytr[playwright]' && playwright install chromium), "
+            '"awswaf" (pure Python, no browser), an empty value to send no token at all, or a '
+            "token string, e.g. an aws-waf-token cookie captured from a browser session."
+        ),
         default="playwright",
     )
     parser_login_args.add_argument(


### PR DESCRIPTION
The Playwright strategy pulls in a ~130 MB package and a ~630 MB Chromium download for one job: fetching an AWS WAF token once per web login. Not every deployment is challenged by that WAF, and the pure-Python `awswaf` strategy solves the same challenge without a browser. Three changes so that choice is actually available:

* `playwright` moves to an optional extra and is imported inside `_fetch_waf_token_playwright` instead of at module level, so `import pytr.api` no longer requires it. A missing install is reported with the command that fixes it.

* The retry branch that ran `playwright install chromium` via subprocess is gone. It was reached by *any* exception -- a timeout, a network blip, a WAF change -- and answered all of them by downloading and executing a browser at runtime, inside the process holding the user's PIN and cookies, bypassing whatever pinning the installing environment had applied. It only ever helped for one of the failures that reached it.

* `pytr.awswaf` is imported lazily too (it reads webgl.json at import time), and its two unbounded loops are bounded, because switching to it as a fallback puts them on the login path:
  - the challenge.js host is scraped out of the login page with a regex and then requested; it is now required to be `*.token.awswaf.com`, which removes the request-forgery primitive.
  - `hash_pow` and `compute_scrypt_nonce` looped over `itertools.count()` with no exit but success, while `difficulty` comes from the server. Anything above 256 can never be satisfied at all. Both now stop, and `build_payload` raises instead of posting a null solution.
  - `network_bandwidth` allocated a buffer sized by a number parsed out of challenge.js. Capped at the largest size AWS' own table uses.

CLI behaviour is unchanged: `--waf-token` still defaults to `playwright`, and its help text now names the extra and the browser-free alternative.

By @tharshan09