### PR TITLE
Cleanup login options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ __Table of Contents__
 * [Quickstart](#quickstart)
 * [Usage](#usage)
 * [Authentication](#authentication)
-  * [Web login (default)](#web-login-default)
-  * [App login](#app-login)
+  * [Web login](#web-login)
 * [Development](#development)
   * [Setting Up a Development Environment](#setting-up-a-development-environment)
   * [Linting and Code Formatting](#linting-and-code-formatting)
@@ -96,39 +95,26 @@ Options:
 
 ## Authentication
 
-There are two authentication methods:
-
-### Web login (default)
+### Web login
 
 Web login uses the public web-login endpoints at `api.traderepublic.com`. Two variants are available:
 
 - **v1 (default)**: `pytr login`. You receive a four-digit code in the TradeRepublic app (or via SMS as a
   fallback) and enter it in the terminal. This is the original behavior; nothing changes for existing users.
+  v1 requires passing an AWS WAF token with the login request; by default pytr fetches one automatically
+  via Playwright (requires the optional `playwright` extra: `pip install 'pytr[playwright]' && playwright install chromium`).
+  The pure-Python alternative `--waf-token awswaf` exists but has been reported to no longer work reliably.
 - **v2 (opt-in)**: `pytr login --v2`. Mirrors what
   [app.traderepublic.com](https://app.traderepublic.com/) currently does. Instead of typing a four-digit code, you
   confirm the login from a push notification in the Trade Republic mobile app. Accounts secured with an authenticator
   app are asked for a code from that app instead. Useful if your account no longer issues a code via the app or SMS.
+  v2 does not require a WAF token; pytr skips it automatically when `--v2` is used.
   Note that Trade Republic removed the SMS resend endpoint along with the v1 web login, so there is no SMS fallback
   under `--v2`. The flag is available on every subcommand that performs a login, e.g. `pytr portfolio --v2`,
   `pytr dl_docs --v2`.
 
 Both variants keep you logged in on your primary device, but you may need to re-authenticate every so often when
 running `pytr`.
-
-### App login
-
-App login is the older method that uses the same login method as the TradeRepublic app. First you need to perform a
-device reset - a private key will be generated that pins your "device". The private key is saved to your keyfile. This
-procedure will log you out from your mobile device.
-
-```sh
- pytr login
- # or
- pytr login --phone_no +49123456789 --pin 1234
-```
-
-If no arguments are supplied pytr will look for them in the file `~/.pytr/credentials` (the first line must contain
-the phone number, the second line the pin). If the file doesn't exist pytr will ask for for the phone number and pin.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dependencies = [
 # fetches separately. The pure-Python `--waf-token awswaf` path solves the same
 # challenge without either, so deployments that use it — or that find their IP
 # is not challenged at all — should not have to carry the browser.
-playwright = ["playwright"]
+playwright = [
+    "playwright>=1.62.0",
+]
 
 [project.scripts]
 pytr = "pytr.main:main"

--- a/pytr/api.py
+++ b/pytr/api.py
@@ -116,14 +116,16 @@ class TradeRepublicApi:
         save_cookies=False,
         credentials_file=None,
         cookies_file=None,
-        waf_token="playwright",
         use_v2_login=False,
+        waf_token="default",
     ):
         self.log = get_logger(__name__)
         self._locale = locale
         self._save_cookies = save_cookies
-        self._waf_token = waf_token
         self._use_v2_login = use_v2_login
+        self._waf_token = waf_token
+        if self._waf_token == "default":
+            self._waf_token = None if self._use_v2_login else "playwright"
 
         self._credentials_file = pathlib.Path(credentials_file) if credentials_file else CREDENTIALS_FILE
 
@@ -204,12 +206,12 @@ class TradeRepublicApi:
         try:
             from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
         except ImportError:
-            self.log.error(
-                "Failed to get AWS WAF token: playwright is not installed. "
+            raise ValueError(
+                "playwright is not installed. "
                 "Install the optional extra with `pip install 'pytr[playwright]'` "
-                "and then run `playwright install chromium`."
-            )
-            raise
+                "and then run `playwright install chromium`. "
+                "Alternatively, use --v2 which does not require a WAF token."
+            ) from None
 
         self.log.info("Retrieving AWS WAF token using Playwright...")
 
@@ -237,7 +239,13 @@ class TradeRepublicApi:
                         break
                     time.sleep(0.5)
                 browser.close()
-        except Exception:
+        except Exception as e:
+            if "Executable doesn't exist" in str(e):
+                raise ValueError(
+                    "Chromium is not installed. "
+                    "Run `playwright install chromium` to download it. "
+                    "Alternatively, use --v2 which does not require a WAF token."
+                ) from None
             self.log.error("Failed to get AWS WAF token.")
             raise
 
@@ -326,16 +334,20 @@ class TradeRepublicApi:
 
         if self._waf_token == "awswaf":
             self._waf_token = self._fetch_waf_token_awswaf()
+            if not self._waf_token:
+                self.log.warning("No WAF token available.")
         elif self._waf_token == "playwright":
             self._waf_token = self._fetch_waf_token_playwright()
+            if not self._waf_token:
+                self.log.warning("No WAF token available.")
         elif self._waf_token:
             self.log.info("Using WAF token from arguments.")
+        else:
+            self.log.info("WAF token skipped.")
 
         if self._waf_token:
             self.log.debug(f"WAF Token: {self._waf_token}")
             self._set_waf_cookie(self._waf_token)
-        else:
-            self.log.warning("No WAF token available.")
 
         extra_headers = self._login_headers() if self._use_v2_login else None
         login_path = "/api/v2/auth/web/login" if self._use_v2_login else "/api/v1/auth/web/login"
@@ -345,6 +357,14 @@ class TradeRepublicApi:
             headers=extra_headers,
         )
         self.log.debug(f"Web login returned: {r.status_code}")
+        if r.status_code == 405 and "awselb" in r.headers.get("server", "").lower():
+            hint = (
+                f"The request was blocked by the AWS load balancer before reaching Trade Republic "
+                f"(server: {r.headers.get('server')}, empty body). "
+                "This means the AWS WAF token is missing or was rejected. "
+                "Try using --waf-token playwright to obtain a valid token, or switch to --v2 which does not require a WAF token."
+            )
+            raise ValueError(hint)
         r.raise_for_status()
         j = r.json()
         self.log.debug(f"Web login data: {json.dumps(j, indent=4)}")

--- a/pytr/main.py
+++ b/pytr/main.py
@@ -80,15 +80,25 @@ def get_main_parser():
     parser_login_args = argparse.ArgumentParser(add_help=False)
     parser_login_args.add_argument("-n", "--phone_no", help="TradeRepublic phone number (international format)")
     parser_login_args.add_argument("-p", "--pin", help="TradeRepublic pin")
-    parser_login_args.add_argument(
+    waf_group = parser_login_args.add_mutually_exclusive_group()
+    waf_group.add_argument(
         "--waf-token",
         help=(
-            'AWS WAF token value or the method to obtain it. Values: "playwright" (needs the '
-            "optional extra: pip install 'pytr[playwright]' && playwright install chromium), "
-            '"awswaf" (pure Python, no browser), an empty value to send no token at all, or a '
-            "token string, e.g. an aws-waf-token cookie captured from a browser session."
+            "AWS WAF token string or the method to obtain it. Possible values: "
+            "\"playwright\" (to use playwright to obtain a token, needs the optional extra: pip install 'pytr[playwright]' && playwright install chromium), "
+            '"awswaf" (to use a pure Python implementation to obtain a token, no browser), '
+            '"default" (let pytr determine what to do, e.g. by login method used.), '
+            "or a token string, e.g. captured from a browser session."
         ),
-        default="playwright",
+        default="default",
+        dest="waf_token",
+    )
+    waf_group.add_argument(
+        "--no-waf-token",
+        help="Skip the AWS WAF token entirely.",
+        action="store_const",
+        const=None,
+        dest="waf_token",
     )
     parser_login_args.add_argument(
         "--store_credentials",


### PR DESCRIPTION
Improve documentation and error messages for trade republic login options.
Default login option is v1, using the playwright method to obtain the AWS WAF token.
New login option -v2 is not using an AWS WAF token by default.
Error messages when playwright/chromium are not available are improved and also if WAF token was likely rejected. Documentation for old App Login was removed from README.md since the feature had been removed some time ago.
