### PR TITLE
Add a test fixture for testing incoming transfer without eventType field

### DIFF
--- a/tests/events/securities_transfer_incoming_no_eventType.json
+++ b/tests/events/securities_transfer_incoming_no_eventType.json
@@ -9,7 +9,6 @@
     "payload": "756ce232-a67d-4d85-a431-57483426450a"
   },
   "cashAccountNumber": "123456789",
-  "eventType": null,
   "hidden": false,
   "deleted": false,
   "source": "timelineActivity",

--- a/tests/events/securities_transfer_incoming_null_eventType.json
+++ b/tests/events/securities_transfer_incoming_null_eventType.json
@@ -1,0 +1,83 @@
+{
+  "id": "756ce232-a67d-4d85-a431-57483426450a",
+  "timestamp": "2025-10-13T12:43:03.988+0000",
+  "title": "MSCI EM USD (Acc)",
+  "icon": "logos/IE00BTJRMP35/v2",
+  "subtitle": "Aktien erhalten",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "756ce232-a67d-4d85-a431-57483426450a"
+  },
+  "cashAccountNumber": "123456789",
+  "eventType": null,
+  "hidden": false,
+  "deleted": false,
+  "source": "timelineActivity",
+  "details": {
+    "id": "756ce232-a67d-4d85-a431-57483426450a",
+    "sections": [
+      {
+        "type": "header",
+        "title": "You received 7 shares",
+        "data": {
+          "status": "executed",
+          "icon": "logos/IE00BTJRMP35/v2",
+          "timestamp": "2025-10-13T12:43:03.988647Z"
+        }
+      },
+      {
+        "type": "table",
+        "title": "Overview",
+        "data": [
+          {
+            "title": "Status",
+            "style": "plain",
+            "detail": {
+              "type": "status",
+              "text": "Completed",
+              "functionalStyle": "EXECUTED"
+            }
+          },
+          {
+            "title": "Asset",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "MSCI EM USD (Acc)"
+            }
+          },
+          {
+            "title": "Action",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Securities transfer"
+            }
+          }
+        ]
+      },
+      {
+        "type": "table",
+        "title": "Transaction",
+        "data": [
+          {
+            "title": "Shares",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "7"
+            }
+          },
+          {
+            "title": "Fee",
+            "style": "plain",
+            "detail": {
+              "type": "text",
+              "text": "Free"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1774,6 +1774,24 @@ test_data: list[dict] = [
         ],
     },
     {
+        "filename": "securities_transfer_incoming_null_eventType.json",
+        "event_type": PPEventType.TRANSFER_IN,
+        "title": "MSCI EM USD (Acc)",
+        "isin": "IE00BTJRMP35",
+        "shares": 7,
+        "value": 0,
+        "transactions": [
+            {
+                "Datum": "2025-10-13T12:43:03",
+                "Typ": "Umbuchung (Eingang)",
+                "Wert": 0,
+                "Notiz": "MSCI EM USD (Acc)",
+                "ISIN": "IE00BTJRMP35",
+                "Stück": 7.0,
+            }
+        ],
+    },
+    {
         "filename": "sell_stop.json",
         "event_type": ConditionalEventType.TRADE_INVOICE,
         "title": "D-Wave Quantum",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1774,7 +1774,7 @@ test_data: list[dict] = [
         ],
     },
     {
-        "filename": "securities_transfer_incoming_null_eventType.json",
+        "filename": "securities_transfer_incoming_no_eventType.json",
         "event_type": PPEventType.TRANSFER_IN,
         "title": "MSCI EM USD (Acc)",
         "isin": "IE00BTJRMP35",


### PR DESCRIPTION
Makes sure the issue of #350 does not reoccur.