### PR TITLE
Make the README mksync check runnable on macOS

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,7 +37,13 @@ jobs:
       - name: Mypy type check
         run: uv run mypy .
       - name: Check if README.md automatically generated content is up to date
-        run: diff -u <(cat README.md | sed -z '$s/\n*$//') <(uvx mksync@0.1.5 README.md | sed -z '$s/\n*$//')
+        # Both sides are normalised to end in exactly one newline before comparing.
+        # `$(...)` strips every trailing newline and `printf` puts one back, which is
+        # what `sed -z '$s/\n*$//'` did here, minus the `-z`: that flag is GNU-only, so
+        # on BSD/macOS sed it failed on both sides and the step compared two empty
+        # streams and always passed. Contributors could not reproduce this check
+        # locally, and it reported success on a README that was in fact stale.
+        run: diff -u <(printf '%s\n' "$(cat README.md)") <(printf '%s\n' "$(uvx mksync@0.1.5 README.md)")
 
   build-n-publish:
     name: Build and publish Python distributions to PyPI


### PR DESCRIPTION
## Summary

The README check normalises both sides before diffing:

```sh
diff -u <(cat README.md | sed -z '$s/\n*$//') <(uvx mksync@0.1.5 README.md | sed -z '$s/\n*$//')
```

`-z` is a GNU extension. BSD sed, which is what macOS ships, rejects it:

```
sed: illegal option -- z
```

Because the flag fails on **both** sides, `diff` ends up comparing two empty streams and the command exits 0. On a Mac it does not merely fail to work: it reports success on a README that is actually stale. A contributor who runs the check locally before pushing gets a green result and then a red CI, which is a confusing way to lose half an hour. That is exactly what happened to me on #382.

## Fix

```sh
diff -u <(printf '%s\n' "$(cat README.md)") <(printf '%s\n' "$(uvx mksync@0.1.5 README.md)")
```

`$(...)` already strips every trailing newline, and `printf '%s\n'` puts exactly one back, so the normalisation is identical with no GNU-only flag. The `diff -u` output on failure is unchanged.

## Verified on macOS

| | current README | README with a heading added, TOC not regenerated |
|---|---|---|
| old command | exit 0 | **exit 0** (wrong) |
| new command | exit 0 | exit 1, with the expected one-line TOC diff |

I also parsed the workflow YAML, extracted the `run:` string, and executed it verbatim to confirm both outcomes, rather than testing a hand-retyped approximation of it.

CI on Linux is unaffected, since both forms normalise the same way there.
