### PR TITLE
Classify Ausschüttungsgleicher Ertrag tax events as TAXES

### DIFF
--- a/pytr/event.py
+++ b/pytr/event.py
@@ -473,6 +473,11 @@ class Event:
                     event_type = PPEventType.TAXES
                 else:
                     event_type = PPEventType.DIVIDEND
+            elif eventTypeStr == "SSP_CORPORATE_ACTION_DIVIDEND_EQUIVALENT":
+                # "Ausschüttungsgleicher Ertrag": tax withheld on a deemed/notional distribution.
+                # This event type only ever carries a "Steuer" line item (no gross distribution),
+                # so it is always a tax event, even when the amount is 0.
+                event_type = PPEventType.TAXES
 
         # Now try to deduct the event type from the title if we still don't have one
         if event_type is None and eventTypeStr not in events_known_ignored:

--- a/tests/events/ausschuettungsgleicher_ertrag.json
+++ b/tests/events/ausschuettungsgleicher_ertrag.json
@@ -1,0 +1,106 @@
+{
+  "id": "1a6011ca-3b48-3950-9373-21696e352b91",
+  "timestamp": "2026-07-28T07:14:09.084+0000",
+  "title": "MSCI World USD (Dist)",
+  "icon": "logos/IE00BK1PV551/v2",
+  "avatar": {
+    "asset": "logos/IE00BK1PV551/v2",
+    "badge": null
+  },
+  "badge": null,
+  "subtitle": "Ausschüttung / Ausschüttungsgleicher Ertrag",
+  "amount": {
+    "currency": "EUR",
+    "value": -3.4,
+    "fractionDigits": 2
+  },
+  "subAmount": null,
+  "status": "EXECUTED",
+  "action": {
+    "type": "timelineDetail",
+    "payload": "1a6011ca-3b48-3950-9373-21696e352b91"
+  },
+  "cashAccountNumber": "123456789",
+  "hidden": false,
+  "deleted": false,
+  "eventType": "SSP_CORPORATE_ACTION_DIVIDEND_EQUIVALENT",
+  "source": "timelineTransaction",
+  "details": {
+    "id": "1a6011ca-3b48-3950-9373-21696e352b91",
+    "sections": [
+      {
+        "title": "Du hast 3,40 € bezahlt",
+        "data": {
+          "icon": {
+            "asset": "logos/IE00BK1PV551/v2",
+            "badge": null
+          },
+          "subtitleText": "28 Juli · 07:14",
+          "status": "executed"
+        },
+        "type": "header"
+      },
+      {
+        "title": "Übersicht",
+        "data": [
+          {
+            "title": "Status",
+            "detail": {
+              "text": "Ausgeführt",
+              "functionalStyle": "EXECUTED",
+              "type": "status"
+            },
+            "style": "plain"
+          },
+          {
+            "title": "Wertpapier",
+            "detail": {
+              "text": "MSCI World USD (Dist)",
+              "displayValue": {
+                "text": "MSCI World USD (Dist)",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Geschäft",
+        "data": [
+          {
+            "title": "Steuer",
+            "detail": {
+              "text": "-3,40 €",
+              "displayValue": {
+                "text": "-3,40 €",
+                "textDataSensitivity": "PUBLIC"
+              },
+              "type": "text"
+            },
+            "style": "plain"
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "title": "Dokumente",
+        "data": [
+          {
+            "title": "Ausschüttung / Ausschüttungsgleicher Ertrag",
+            "detail": "28.07.2026",
+            "action": {
+              "payload": "https://example.com/ausschuettungsgleicher_ertrag.pdf",
+              "type": "browserModal"
+            },
+            "id": "099a180a-b878-4ac8-bda8-e5a272c649d0",
+            "postboxType": "DIVIDEND_EQUIVALENT_TAX_INVOICE"
+          }
+        ],
+        "type": "documents"
+      }
+    ]
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -270,6 +270,24 @@ test_data: list[dict] = [
         ],
     },
     {
+        "filename": "ausschuettungsgleicher_ertrag.json",
+        "event_type": PPEventType.TAXES,
+        "title": "MSCI World USD (Dist)",
+        "isin": "IE00BK1PV551",
+        "value": -3.4,
+        "taxes": 3.4,
+        "transactions": [
+            {
+                "Datum": "2026-07-28T07:14:09",
+                "Typ": "Steuern",
+                "Wert": -3.4,
+                "Notiz": "MSCI World USD (Dist)",
+                "ISIN": "IE00BK1PV551",
+                "Steuern": 3.4,
+            }
+        ],
+    },
+    {
         "filename": "bardividende.json",
         "event_type": PPEventType.DIVIDEND,
         "title": "Comcast (A)",


### PR DESCRIPTION
SSP_CORPORATE_ACTION_DIVIDEND_EQUIVALENT was not in the event type mapping, so these events resolved to event_type=None and were silently dropped from the CSV export (their documents still downloaded fine, since that path is independent).

This event type only ever carries a "Steuer" line (no gross distribution), so map it unconditionally to TAXES, even when the amount is 0.

For context: In the Austrian tax system, investment funds (both accumulating and distributing ETFs) frequently generate what is called 'ausschüttungsgleiche Erträge' (dividend equivalent income). This occurs when a fund retains and reinvests earnings instead of distributing 100% of them. These retained earnings are subject to taxation even though no actual cash is distributed to the user's account. The broker generates a specific tax event and document for this scenario, which this PR now correctly identifies and parses.